### PR TITLE
re-ordered api fetch call

### DIFF
--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -40,6 +40,8 @@ def notify_interactive():
 
 
 def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour, add_date):
+    tour = api.fetch_tour(str(tour_id))
+
     # Example date: 2022-01-02T12:26:41.795+01:00
     # :10 extracts "2022-01-02" from this.
     date_str = tour['date'][:10]+'_' if add_date else ''
@@ -50,7 +52,6 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour, add_date):
         print_success(f"{tour['name']} skipped - already exists at '{path}'")
         return
 
-    tour = api.fetch_tour(str(tour_id))
     gpx = GpxCompiler(tour, api, no_poi)
 
     f = open(path, "w", encoding="utf-8")


### PR DESCRIPTION
### Issue
I encountered the following issue when grabbing a `.gpx`:
```bash
  File "<my_redacted_path>/komootgpx/komootgpx.py", line 47, in make_gpx
    path = f"{output_dir}/{date_str}{sanitize_filename(tour['name'])}-{tour_id}.gpx"
                                                       ~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```
### Analysis
This happens due to Type `None` for the `tour` variable. It seems that the order is questionable, because the `tour` variable is already used for building the file name although it was not initialized before.  

### Solution
This PR re-orders the api fetch call to be one of the first steps. This helps to have the `tour` variable available for path building etc. 

This problem occurred from a non-authenticated `.gpx` grab. Hope this discrupts no other logic when using the account credentials. 