### PR TITLE
add explicit --anonymous mode and cleanup the flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,19 @@ komootgpx.py [options]
 [Authentication]
         -m, --mail=mail_address            Login using specified email address
         -p, --pass=password                Use provided password and skip interactive prompt
+        -n, --anonymous                    Skip authentication, no interactive prompt, valid only with -d
+
 [Tours]
         -l, --list-tours                   List all tours of the logged in user
         -d, --make-gpx=tour_id             Download tour as GPX
         -a, --make-all                     Download all tours
+        -s, --skip-existing                Do not download and save GPX if the file already exists, ignored with -d
         -D, --add-date                     Add date to file name
+
 [Filters]
         -f, --filter=type                  Filter by track type (either "planned" or "recorded")
+
 [Generator]
         -o, --output                       Output directory (default: working directory)
         -e, --no-poi                       Do not include highlights as POIs
-        -s, --skip-existing                Do not download and save GPX if the file already exists, ignored with -d
 ```

--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ komootgpx.py [options]
 [Generator]
         -o, --output                       Output directory (default: working directory)
         -e, --no-poi                       Do not include highlights as POIs
+        -s, --skip-existing                Do not download and save GPX if the file already exists, ignored with -d
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python -m komootgpx --help
 
 ## Usage
 
-Run script in interactive mode
+### Run script in interactive mode
 ```
 komootgpx
 ```
@@ -44,7 +44,7 @@ Fetching highlight '15840XX'...
 GPX file written to '~/Development/KomootGPX/Example trip A-3331210XX.gpx'
 ```
 
-Display advanced usage information
+### Display advanced usage information
 ```
 komootgpx --help
 ```
@@ -69,3 +69,11 @@ komootgpx.py [options]
         -o, --output                       Output directory (default: working directory)
         -e, --no-poi                       Do not include highlights as POIs
 ```
+
+### Authentication
+It's required to be properly authenticated with username (email) and password to perform most of available operations:
+ * list user's tours (both planned and completed)
+ * download all tours
+ * download tour that has Visibility set to "Only me" or "Close friends"
+
+Without authentication you can download any tour that is public (i.e. Visibility set to "Anyone"). To disable authentication use `--anonymous` option.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Download from [PyPI](https://pypi.org/project/komootgpx/):
 ```
 pip install komootgpx
 ```
+
+## Testing
+To run from local clone of repo (without installation):
+```
+python -m komootgpx --help
+```
+
 ## Usage
 
 Run script in interactive mode

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -14,22 +14,26 @@ interactive_info_shown = False
 
 def usage():
     print(bcolor.HEADER + bcolor.BOLD + 'komootgpx.py [options]' + bcolor.ENDC)
+
     print(bcolor.OKBLUE + '[Authentication]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-m', '--mail=mail_address', 'Login using specified email address'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-p', '--pass=password',
                                              'Use provided password and skip interactive prompt'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-n', '--anonymous', 'Skip authentication, valid only with -d'))
+
     print(bcolor.OKBLUE + '[Tours]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-l', '--list-tours', 'List all tours of the logged in user'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-d', '--make-gpx=tour_id', 'Download tour as GPX'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-a', '--make-all', 'Download all tours'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-s', '--skip-existing', 'Do not download and save GPX if the file already exists, ignored with -d'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add date to file name'))
+
     print(bcolor.OKBLUE + '[Filters]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filter=type', 'Filter by track type (either "planned" or '
                                                                     '"recorded")'))
     print(bcolor.OKBLUE + '[Generator]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-o', '--output', 'Output directory (default: working directory)'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--no-poi', 'Do not include highlights as POIs'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-s', '--skip-existing', 'Do not download and save GPX if the file already exists, ignored with -d'))
 
 
 def notify_interactive():
@@ -39,18 +43,24 @@ def notify_interactive():
         print("Interactive mode. Use '--help' for usage details.")
 
 
-def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour, add_date):
+def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date):
+    tour = None
+    if tour_base is None:
+        tour_base = api.fetch_tour(str(tour_id))
+        tour = tour_base
+
     # Example date: 2022-01-02T12:26:41.795+01:00
     # :10 extracts "2022-01-02" from this.
-    date_str = tour['date'][:10]+'_' if add_date else ''
+    date_str = tour_base['date'][:10]+'_' if add_date else ''
 
     path = f"{output_dir}/{date_str}{sanitize_filename(tour['name'])}-{tour_id}.gpx"
 
     if skip_existing and os.path.exists(path):
-        print_success(f"{tour['name']} skipped - already exists at '{path}'")
+        print_success(f"{tour_base['name']} skipped - already exists at '{path}'")
         return
 
-    tour = api.fetch_tour(str(tour_id))
+    if tour is None:
+        tour = api.fetch_tour(str(tour_id))
     gpx = GpxCompiler(tour, api, no_poi)
 
     f = open(path, "w", encoding="utf-8")
@@ -68,22 +78,23 @@ def main(argv):
     no_poi = False
     skip_existing = False
     add_date = False
+    anonymous = False
     typeFilter = "all"
     output_dir = os.getcwd()
 
     try:
-        opts, args = getopt.getopt(argv, "ahlesDo:d:m:p:f:", ["add-date", "list-tours", "make-gpx=", "mail=",
-                                                        "pass=", "filter=", "no-poi", "output=", "skip-existing", "make-all"])
+        opts, args = getopt.getopt(argv, "ahlesDno:d:m:p:f:",
+            ["add-date", "list-tours", "make-gpx=", "mail=", "pass=", "filter=", "no-poi", "output=", "skip-existing", "make-all", "anonymous"])
     except getopt.GetoptError:
         usage()
         sys.exit(2)
 
     for opt, arg in opts:
-        if opt == '-h':
+        if opt in ("-h", "--help"):
             usage()
-            sys.exit()
+            sys.exit(0)
 
-        elif opt in "--filter":
+        elif opt in ("-f", "--filter"):
             typeFilter = "tour_" + str(arg)
 
         elif opt in ("-l", "--list-tours"):
@@ -94,6 +105,9 @@ def main(argv):
 
         elif opt in ("-s", "--skip-existing"):
             skip_existing = True
+
+        elif opt in ("-n", "--anonymous"):
+            anonymous = True
 
         elif opt in ("-D", "--add-date"):
             add_date = True
@@ -113,43 +127,53 @@ def main(argv):
         elif opt in ("-a", "--make-all"):
             tour_selection = "all"
 
-    if tour_selection and tour_selection != "all":
-        api = KomootApi()
-        make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date)
-        return
 
-    if mail == "":
-        notify_interactive()
-        mail = prompt("Enter your mail address (komoot.de)")
+    if anonymous and tour_selection == "all":
+        print_error("Cannot get all user's routes in anonymous mode, use -d")
+        sys.exit(2)
 
-    if pwd == "":
-        notify_interactive()
-        pwd = prompt_pass("Enter your password (input hidden)")
+    if anonymous and (mail != "" or pwd != ""):
+        print_error("Cannot specify login/password in anonymous mode")
+        sys.exit(2)
 
     api = KomootApi()
-    api.login(mail, pwd)
+
+    if not anonymous:
+        if mail == "":
+            notify_interactive()
+            mail = prompt("Enter your mail address (komoot.de)")
+
+        if pwd == "":
+            notify_interactive()
+            pwd = prompt_pass("Enter your password (input hidden)")
+
+        api.login(mail, pwd)
+
+        if print_tours:
+            api.print_tours(typeFilter)
+            sys.exit(0)
+
+        tours = api.fetch_tours(typeFilter)
 
     if tour_selection == "":
         notify_interactive()
         api.print_tours(typeFilter)
         tour_selection = prompt("Enter a tour id to download")
 
-    if print_tours:
-        api.print_tours(typeFilter)
-        exit(0)
-
-    tours = api.fetch_tours(typeFilter)
-
-    if tour_selection != "all" and int(tour_selection) not in tours:
-        print_error("Unknown tour id selected. These are all available tours on your profile:")
-        api.print_tours(typeFilter)
-        exit(0)
+    if not anonymous and tour_selection != "all" and int(tour_selection) not in tours:
+        print_warning(f"Warning: This id ({tour_selection}) is not one of your tours. Use --list-tours to view complete list.")
 
     if tour_selection == "all":
         for x in tours:
             make_gpx(x, api, output_dir, no_poi, skip_existing, tours[x], add_date)
     else:
-        make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[tour_selection], add_date)
+        if anonymous:
+            make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date)
+        else:
+            if int(tour_selection) in tours:
+                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[tour_selection], add_date)
+            else:
+                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date)
     print()
 
 
@@ -159,4 +183,4 @@ def entrypoint():
     except KeyboardInterrupt:
         print()
         print_error("Aborted by user")
-        exit(1)
+        sys.exit(1)

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -140,7 +140,7 @@ def main(argv):
     if not anonymous:
         if mail == "":
             notify_interactive()
-            mail = prompt("Enter your mail address (komoot.de)")
+            mail = prompt("Enter your mail address (komoot login)")
 
         if pwd == "":
             notify_interactive()

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -17,9 +17,8 @@ def usage():
 
     print(bcolor.OKBLUE + '[Authentication]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-m', '--mail=mail_address', 'Login using specified email address'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-p', '--pass=password',
-                                             'Use provided password and skip interactive prompt'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-n', '--anonymous', 'Skip authentication, valid only with -d'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-p', '--pass=password', 'Use provided password and skip interactive prompt'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-n', '--anonymous', 'Skip authentication, no interactive prompt, valid only with -d'))
 
     print(bcolor.OKBLUE + '[Tours]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-l', '--list-tours', 'List all tours of the logged in user'))
@@ -29,8 +28,8 @@ def usage():
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add date to file name'))
 
     print(bcolor.OKBLUE + '[Filters]' + bcolor.ENDC)
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filter=type', 'Filter by track type (either "planned" or '
-                                                                    '"recorded")'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filter=type', 'Filter by track type (either "planned" or "recorded")'))
+
     print(bcolor.OKBLUE + '[Generator]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-o', '--output', 'Output directory (default: working directory)'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--no-poi', 'Do not include highlights as POIs'))

--- a/komootgpx/utils.py
+++ b/komootgpx/utils.py
@@ -26,6 +26,8 @@ def print_error(text):
 def print_success(text):
     print(bcolor.OKGREEN + text + bcolor.ENDC)
 
+def print_warning(text):
+    print(bcolor.WARNING + text + bcolor.ENDC)
 
 def prompt(title):
     print()

--- a/tools/cleanup.pl
+++ b/tools/cleanup.pl
@@ -10,26 +10,20 @@
 
 use strict;
 use warnings;
-use Data::Dumper;
 my %h;
 my %fn;
 
-my @a = sort <*.gpx>;
-for (@a)
+for (sort <*.gpx>)
 {
     next unless m/^(\d\d\d\d-\d\d-\d\d).*-(\d+)\.gpx$/;
-    my $d = $1;
-    my $id = $2;
+    my ($d, $id) = ($1, $2);
 
-    if (!exists $h{$id})
+    if (exists $h{$id})
     {
-        $h{$id} = $d;
-        $fn{$id} = $_;
-        next;
+        print "unlink $id -> $h{$id}: $fn{$id}\n";
+        unlink $fn{$id} or die $!;
     }
 
-    print "unlink $id -> $h{$id}: $fn{$id}\n";
-    unlink $fn{$id} or die $!;
     $h{$id} = $d;
     $fn{$id} = $_;
 }

--- a/tools/cleanup.pl
+++ b/tools/cleanup.pl
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+
+# Edited tracks are re-downloaded with new date and same id
+# so with --add-date you end up with several files.
+# Use this script to remove all but the latest version.
+
+# e.g.
+# 2021-01-01_trip-12345.gpx <- this one is deleted
+# 2024-05-05_trip-12345.gpx
+
+use strict;
+use warnings;
+use Data::Dumper;
+my %h;
+my %fn;
+
+my @a = sort <*.gpx>;
+for (@a)
+{
+    next unless m/^(\d\d\d\d-\d\d-\d\d).*-(\d+)\.gpx$/;
+    my $d = $1;
+    my $id = $2;
+
+    if (!exists $h{$id})
+    {
+        $h{$id} = $d;
+        $fn{$id} = $_;
+        next;
+    }
+
+    print "unlink $id -> $h{$id}: $fn{$id}\n";
+    unlink $fn{$id} or die $!;
+    $h{$id} = $d;
+    $fn{$id} = $_;
+}


### PR DESCRIPTION
As discussed in https://github.com/timschneeb/KomootGPX/pull/13 I added `--anonymous` / `-n` switch to force skipping authentication (and updated code flow accordingly). Additionally I updated README.md with all options (in previous PR I forgot to add --skip-existing to the README) and some explanation of authentication.

I switched "Unknown tour id selected" fatal error to a warning (I added proper function in utils) because in current flow there's no early bailout for `--make-gpx` / `-d`.

Additionally there are some smaller fixes included (like missing switches in getopt, exit without sys etc.)