### PR TITLE
Fix bug #24 - tour type filtering for all (both) types

### DIFF
--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -44,7 +44,7 @@ class KomootApi:
 
         print("Logged in as '" + r.json()['user']['displayname'] + "'")
 
-    def fetch_tours(self, tour_type="all", silent=False):
+    def fetch_tours(self, tour_type="tour_all", silent=False):
         if not silent:
             print("Fetching tours of user '" + self.user_id + "'...")
 
@@ -60,7 +60,7 @@ class KomootApi:
 
             tours = r.json()['_embedded']['tours']
             for tour in tours:
-                if tour_type != "all" and tour_type != tour['type']:
+                if tour_type != "tour_all" and tour_type != tour['type']:
                     continue
                 results[tour['id']] = tour
 

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -234,7 +234,7 @@ def main(args):
         api.login(mail, pwd)
 
         if print_tours:
-            tours = api.fetch_tours(silent=True, tour_type=tour_type)
+            tours = api.fetch_tours(tour_type=tour_type, silent=True)
             list_tours(tours, start_date, end_date)
             sys.exit(0)
 


### PR DESCRIPTION
tour_ prefix is always added in main
```
tour_type = f"tour_{args.tour_type}"
```