### PR TITLE
Implement tour images download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# misc settings and meta files
 .DS_Store
-credentials.json
 .vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.DS_Store
+credentials.json
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ komootgpx.py [options]
         -I, --id-filename                  Use only tour id for filename (no title)
         -D, --add-date                     Add tour date to file name
         --max-title-length=num             Crop title used in filename to given length (default: -1 = no limit)
-        -L, --language                     Set tour description to specific language (fr, de, en..., default: en )
+        -L, --language                     Set tour description to specific language (fr, de, en..., default: en)
 
 [Filters]
         -t, --tour-type=type               Filter by track type ("planned", "recorded" or "all")

--- a/README.md
+++ b/README.md
@@ -85,9 +85,12 @@ komootgpx.py [options]
 
 [Generator]
         -o, --output=directory             Output directory (default: working directory)
-        -i, --no-image                     Do not download tour images
         -e, --no-poi                       Do not include highlights as POIs
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
+
+[Images]
+        --account-images-only              Only download images belong to this account
+        -i, --no-image                     Do not download tour images
 
 [Other]
         --debug                            Save all Komoot API responses in set of .txt files

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ komootgpx.py [options]
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
 
 [Images]
-        --account-images-only              Only download images belong to this account
         -i, --add-images                   Add tour images
+        --all-images                       Download images from other users too - copyright review is required
 
 [Other]
         --debug                            Save all Komoot API responses in set of .txt files

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ komootgpx.py [options]
 
 [Images]
         --account-images-only              Only download images belong to this account
-        -i, --no-image                     Do not download tour images
+        -i, --add-images                   Add tour images
 
 [Other]
         --debug                            Save all Komoot API responses in set of .txt files

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ komootgpx.py [options]
 
 [Generator]
         -o, --output=directory             Output directory (default: working directory)
+        -i, --no-image                     Do not download tour images
         -e, --no-poi                       Do not include highlights as POIs
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ komootgpx.py [options]
         -I, --id-filename                  Use only tour id for filename (no title)
         -D, --add-date                     Add tour date to file name
         --max-title-length=num             Crop title used in filename to given length (default: -1 = no limit)
+        -L, --language                     Set tour description to specific language (fr, de, en..., default: en )
 
 [Filters]
         -t, --tour-type=type               Filter by track type ("planned", "recorded" or "all")

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -122,3 +122,13 @@ class KomootApi:
 
         print("Found " + str(len(results)) + " images")
         return results
+
+    def fetch_highlight(self, highlight_id, silent=False):
+        if not silent:
+            print("Fetching highlight '" + str(highlight_id) + "'...")
+
+        results = {}
+        current_uri = "https://api.komoot.de/v007/highlights/" + str(highlight_id)
+        r = self.__send_request(current_uri, self.__build_header())
+
+        return r.json()

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -82,12 +82,12 @@ class KomootApi:
         print("Found " + str(len(results)) + " tours")
         return results
 
-    def fetch_tour(self, tour_id):
+    def fetch_tour(self, tour_id, hl_lang='en'):
         print("Fetching tour '" + tour_id + "'...")
 
         r = self.__send_request("https://api.komoot.de/v007/tours/" + tour_id + "?_embedded=coordinates,way_types,"
                                                                                 "surfaces,directions,participants,"
-                                                                                "timeline&directions=v2&fields"
+                                                                                "timeline&hl=" + hl_lang + "&directions=v2&fields"
                                                                                 "=timeline&format=coordinate_array"
                                                                                 "&timeline_highlights_fields=tips,"
                                                                                 "recommenders",

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -82,7 +82,7 @@ class KomootApi:
         print("Found " + str(len(results)) + " tours")
         return results
 
-    def fetch_tour(self, tour_id, hl_lang='en'):
+    def fetch_tour(self, tour_id, hl_lang="en"):
         print("Fetching tour '" + tour_id + "'...")
 
         r = self.__send_request("https://api.komoot.de/v007/tours/" + tour_id + "?_embedded=coordinates,way_types,"

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -82,12 +82,12 @@ class KomootApi:
         print("Found " + str(len(results)) + " tours")
         return results
 
-    def fetch_tour(self, tour_id, hl_lang="en"):
+    def fetch_tour(self, tour_id, language="en"):
         print("Fetching tour '" + tour_id + "'...")
 
         r = self.__send_request("https://api.komoot.de/v007/tours/" + tour_id + "?_embedded=coordinates,way_types,"
                                                                                 "surfaces,directions,participants,"
-                                                                                "timeline&hl=" + hl_lang + "&directions=v2&fields"
+                                                                                "timeline&hl=" + language + "&directions=v2&fields"
                                                                                 "=timeline&format=coordinate_array"
                                                                                 "&timeline_highlights_fields=tips,"
                                                                                 "recommenders",

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -116,7 +116,7 @@ class KomootApi:
             if has_next_page:
                 current_uri = r.json()['_links']['next']['href']
 
-            images = r.json()['_embedded']['items']
+            images = r.json().get('_embedded', {}).get('items', [])
             for image in images:
                 results[image['id']] = image
 

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -101,3 +101,24 @@ class KomootApi:
                                 self.__build_header(), critical=False)
 
         return r.json()
+
+    def fetch_tour_images(self, tour_id, silent=False):
+        if not silent:
+            print("Fetching images of tour '" + str(tour_id) + "'...")
+
+        results = {}
+        has_next_page = True
+        current_uri = "https://api.komoot.de/v007/tours/" + tour_id + "/cover_images/"
+        while has_next_page:
+            r = self.__send_request(current_uri, self.__build_header())
+
+            has_next_page = 'next' in r.json()['_links'] and 'href' in r.json()['_links']['next']
+            if has_next_page:
+                current_uri = r.json()['_links']['next']['href']
+
+            images = r.json()['_embedded']['items']
+            for image in images:
+                results[image['id']] = image
+
+        print("Found " + str(len(results)) + " images")
+        return results

--- a/komootgpx/imagedownload.py
+++ b/komootgpx/imagedownload.py
@@ -1,0 +1,114 @@
+import requests
+from datetime import datetime
+from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
+import piexif
+import tempfile
+import shutil
+import os
+
+
+class ImageDownloaderWithExif:
+    def __init__(self, image_data: dict, timezone: str = "UTC"):
+        self.image_data = image_data
+        self.id = image_data["id"]
+        self.src = image_data["src"]
+        self.created_at = image_data["created_at"]
+        self.location = image_data.get("location", {})
+        self.timezone = ZoneInfo(timezone)
+
+    # ---------- public API ----------
+
+    def download_and_save(self, output_path: str) -> str:
+        """
+        Download the image, merge EXIF, and save to the given output path.
+        Preserves original JPEG quality.
+        """
+        # Ensure output directory exists
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+        # Download raw JPEG bytes
+        image_bytes = self._download_image_bytes()
+
+        # Build EXIF
+        exif_bytes = self._build_exif()
+
+        # Use temporary file to insert EXIF
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp.write(image_bytes)
+            tmp.flush()
+            tmp_name = tmp.name
+
+        # Insert EXIF in-place
+        piexif.insert(exif_bytes, tmp_name)
+
+        # Move temp file to final output
+        shutil.move(tmp_name, output_path)
+
+        return output_path
+
+    # ---------- internal helpers ----------
+
+    def _download_image_bytes(self) -> bytes:
+        url = self._strip_url_params(self.src)
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        return resp.content
+
+    def _build_exif(self) -> bytes:
+        created_exif = self._format_created_at_local()
+
+        exif_dict = {
+            "0th": {},
+            "Exif": {
+                piexif.ExifIFD.DateTimeOriginal: created_exif,
+                piexif.ExifIFD.DateTimeDigitized: created_exif,
+            },
+            "GPS": self._gps_exif(),
+            "1st": {},
+        }
+
+        return piexif.dump(exif_dict)
+
+    def _gps_exif(self) -> dict:
+        if not self.location:
+            return {}
+
+        lat = self.location.get("lat")
+        lng = self.location.get("lng")
+        alt = self.location.get("alt", 0)
+
+        return {
+            piexif.GPSIFD.GPSLatitudeRef: b"N" if lat >= 0 else b"S",
+            piexif.GPSIFD.GPSLatitude: self._to_dms_rational(lat),
+            piexif.GPSIFD.GPSLongitudeRef: b"E" if lng >= 0 else b"W",
+            piexif.GPSIFD.GPSLongitude: self._to_dms_rational(lng),
+            piexif.GPSIFD.GPSAltitudeRef: 0,
+            piexif.GPSIFD.GPSAltitude: (int(alt * 100), 100),
+        }
+
+    # ---------- time handling ----------
+
+    def _format_created_at_local(self) -> str:
+        # Parse UTC
+        dt_utc = datetime.strptime(
+            self.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
+        ).replace(tzinfo=ZoneInfo("UTC"))
+        # Convert to target timezone
+        dt_local = dt_utc.astimezone(self.timezone)
+        # EXIF format (no timezone info)
+        return dt_local.strftime("%Y:%m:%d %H:%M:%S")
+
+    # ---------- static helpers ----------
+
+    @staticmethod
+    def _strip_url_params(url: str) -> str:
+        return urlparse(url)._replace(query="").geturl()
+
+    @staticmethod
+    def _to_dms_rational(deg: float):
+        deg_abs = abs(deg)
+        d = int(deg_abs)
+        m = int((deg_abs - d) * 60)
+        s = (deg_abs - d - m / 60) * 3600
+        return [(d, 1), (m, 1), (int(s * 100), 100)]

--- a/komootgpx/imagedownload.py
+++ b/komootgpx/imagedownload.py
@@ -5,7 +5,6 @@ from zoneinfo import ZoneInfo
 import piexif
 import tempfile
 import shutil
-import os
 from io import BytesIO
 from PIL import Image
 from .utils import *

--- a/komootgpx/imagedownload.py
+++ b/komootgpx/imagedownload.py
@@ -16,7 +16,7 @@ class ImageDownloaderWithExif:
         image_data: dict,
         api,
         no_poi,
-        account_images_only,
+        all_images,
         *,
         title: str = "",
         creator: str = "",
@@ -25,7 +25,7 @@ class ImageDownloaderWithExif:
     ):
         self.api = api
         self.no_poi = no_poi
-        self.account_images_only = account_images_only
+        self.all_images = all_images
         self.id = image_data["id"]
         self.name = image_data.get('name', title)
         self.src = image_data["src"]

--- a/komootgpx/imagedownload.py
+++ b/komootgpx/imagedownload.py
@@ -12,6 +12,7 @@ class ImageDownloaderWithExif:
     def __init__(self, image_data: dict, timezone: str = "UTC"):
         self.image_data = image_data
         self.id = image_data["id"]
+        self.name = image_data["name"]
         self.src = image_data["src"]
         self.created_at = image_data["created_at"]
         self.location = image_data.get("location", {})
@@ -59,7 +60,9 @@ class ImageDownloaderWithExif:
         created_exif = self._format_created_at_local()
 
         exif_dict = {
-            "0th": {},
+            "0th": {
+                piexif.ImageIFD.ImageDescription: self.name.encode("utf-8"),
+            },
             "Exif": {
                 piexif.ExifIFD.DateTimeOriginal: created_exif,
                 piexif.ExifIFD.DateTimeDigitized: created_exif,

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -46,6 +46,7 @@ def usage():
 
     print('\n' + bcolor.OKBLUE + '[Generator]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-o', '--output=directory', 'Output directory (default: working directory)'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-i', '--no-image', 'Do not download tour images'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--no-poi', 'Do not include highlights as POIs'))
     print('\t{:<34s} {:<10s}'.format('--max-desc-length=count', 'Limit description length in characters (default: -1 = no limit)'))
 
@@ -277,6 +278,7 @@ def main(args):
 
     add_date = args.add_date
     output_dir = args.output
+    no_image = args.no_image
     no_poi = args.no_poi
 
     # Parse date ranges
@@ -364,17 +366,20 @@ def main(args):
     if tour_selection == "all":
         for x in tours:
             make_gpx(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, max_desc_length)
-            download_tour_images(x, api, output_dir, skip_existing, tours[x], add_date, max_title_length)
+            if not no_image and not anonymous:
+                download_tour_images(x, api, output_dir, skip_existing, tours[x], add_date, max_title_length)
     else:
         if anonymous:
             make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date, max_title_length, max_desc_length)
         else:
             if int(tour_selection) in tours:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, max_desc_length)
-                download_tour_images(tour_selection, api, output_dir, skip_existing, tours[int(tour_selection)], add_date, max_title_length)
+                if not no_image:
+                    download_tour_images(tour_selection, api, output_dir, skip_existing, tours[int(tour_selection)], add_date, max_title_length)
             else:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, max_desc_length)
-                download_tour_images(tour_selection, api, output_dir, skip_existing, None, add_date, max_title_length)
+                if not no_image:
+                    download_tour_images(tour_selection, api, output_dir, skip_existing, None, add_date, max_title_length)
     print()
 
     if remove_deleted:
@@ -421,6 +426,7 @@ def parse_args():
     parser.add_argument("--private-only", action="store_true", help="Include only private tours")
     parser.add_argument("--public-only", action="store_true", help="Include only public tours")
     parser.add_argument("-o", "--output", type=str, default=os.getcwd(), help="Output directory")
+    parser.add_argument("-i", "--no-image", action="store_true", help="Do not download tour images")
     parser.add_argument("-e", "--no-poi", action="store_true", help="Do not include POIs in GPX")
     parser.add_argument("--debug", action="store_true", default=False, help="Debug")
     parser.add_argument("-h", "--help", action="store_true", help="Prints help")

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -51,7 +51,7 @@ def usage():
     print('\t{:<34s} {:<10s}'.format('--max-desc-length=count', 'Limit description length in characters (default: -1 = no limit)'))
 
     print('\n' + bcolor.OKBLUE + '[Images]' + bcolor.ENDC)
-    print('\t{:<34s} {:<10s}'.format('--account-images-only', 'Only download images belong to this account'))
+    print('\t{:<34s} {:<10s}'.format('--all-images', 'Download images from other users too - please review the copyright'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-i', '--add-images', 'Add tour images'))
 
     print('\n' + bcolor.OKBLUE + '[Other]' + bcolor.ENDC)
@@ -185,7 +185,7 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
 
     print_success(f"GPX file written to '{path}'")
 
-def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, account_images_only):
+def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, all_images):
     image_dir_contents = set()
     images = api.fetch_tour_images(str(tour_id), silent=False)
 
@@ -218,7 +218,7 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
             print_success(f"Also skipped image download for highlight/poi: {highlight_id} (--no-poi)")
             continue
 
-        if account_images_only and creator_display_name != api.display_name:
+        if not all_images and creator_display_name != api.display_name:
             print_success(f"Image download skipped for image {id} from: {creator_display_name} - it doesn't belong to user {api.display_name}")
             continue
 
@@ -242,7 +242,7 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
             images[x],
             api,
             no_poi,
-            account_images_only,
+            all_images,
             timezone="UTC"
         )
 
@@ -302,7 +302,7 @@ def main(args):
     no_poi = args.no_poi
     add_images = args.add_images
     language = args.language
-    account_images_only = args.account_images_only
+    all_images = args.all_images
 
     # Parse date ranges
     start_date = None
@@ -390,7 +390,7 @@ def main(args):
         for x in tours:
             make_gpx(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, max_desc_length, language)
             if add_images and not anonymous:
-                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, account_images_only)
+                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, all_images)
     else:
         if anonymous:
             make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date, max_title_length, max_desc_length, language)
@@ -398,11 +398,11 @@ def main(args):
             if int(tour_selection) in tours:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, max_desc_length, language)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, account_images_only)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, all_images)
             else:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, max_desc_length, language)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, account_images_only)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, all_images)
     print()
 
     if remove_deleted:
@@ -451,7 +451,7 @@ def parse_args():
     parser.add_argument("--public-only", action="store_true", help="Include only public tours")
     parser.add_argument("-o", "--output", type=str, default=os.getcwd(), help="Output directory")
     parser.add_argument("-i", "--add-images", action="store_true", default=False, help="Add tour images")
-    parser.add_argument("--account-images-only", action="store_true", help="Only download images belong to this account")
+    parser.add_argument("--all-images", action="store_true", default=False, help="Download images from other users too - please review the copyright")
     parser.add_argument("-e", "--no-poi", action="store_true", help="Do not include POIs in GPX")
     parser.add_argument("--debug", action="store_true", default=False, help="Debug")
     parser.add_argument("-h", "--help", action="store_true", help="Prints help")

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -225,9 +225,12 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
         if not os.path.exists(image_dir):
             os.makedirs(image_dir)
 
+        third_party_copyright = ''
+        if creator_display_name != api.display_name:
+            third_party_copyright = '-3p'
         dt = datetime.strptime(images[x]['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ")
         output_date = dt.strftime("%Y%m%d-%H%M%S")
-        filename = sanitize_filename(output_date + "-" + str(x) + ".jpg")
+        filename = sanitize_filename(output_date + "-hl" + str(x) + third_party_copyright + ".jpg")
 
         path = f"{image_dir}/{filename}"
 

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -34,7 +34,7 @@ def usage():
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-r', '--remove-deleted', 'Remove GPX files (from --output dir) without corresponding tour in Komoot (deleted and previous versions)'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-I', '--id-filename', 'Use only tour id for filename (no title)'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add tour date to file name'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-L', '--language', 'Select description language, default=en'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-L', '--language', 'Select description language (fr, de, en..., default: en)'))
     print('\t{:<34s} {:<10s}'.format('--max-title-length=num', 'Crop title used in filename to given length (default: -1 = no limit)'))
 
     print('\n' + bcolor.OKBLUE + '[Filters]' + bcolor.ENDC)

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -435,7 +435,7 @@ def parse_args():
     parser.add_argument("-p", "--pass", dest="pwd", type=str, help="Password for login")
     parser.add_argument("-n", "--anonymous", action="store_true", default=False, help="Login anonymously")
     parser.add_argument("-l", "--list-tours", action="store_true", help="Print available tours")
-    parser.add_argument("-L", "--language", type=str, help="Select description language (default=en)")
+    parser.add_argument("-L", "--language", type=str, default="en", help="Select description language (default=en)")
     parser.add_argument("-d", "--make-gpx", type=int, help="Download GPX for selected tour")
     parser.add_argument("-a", "--make-all", action="store_true", help="Download all tours")
     parser.add_argument("-s", "--skip-existing", action="store_true", help="Skip already downloaded tours")

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -223,7 +223,7 @@ def download_tour_images(tour_id, api, output_dir, skip_existing, tour_base, add
 
         downloader = ImageDownloaderWithExif(
             images[x],
-            timezone="Europe/Berlin"
+            timezone="UTC"
         )
 
         saved_image = downloader.download_and_save(path)

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -52,7 +52,7 @@ def usage():
 
     print('\n' + bcolor.OKBLUE + '[Images]' + bcolor.ENDC)
     print('\t{:<34s} {:<10s}'.format('--account-images-only', 'Only download images belong to this account'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-i', '--no-image', 'Do not download tour images'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-i', '--add-images', 'Add tour images'))
 
     print('\n' + bcolor.OKBLUE + '[Other]' + bcolor.ENDC)
     print('\t{:<34s} {:<10s}'.format('--debug', 'Save all Komoot API responses in set of .txt files'))
@@ -300,7 +300,7 @@ def main(args):
     add_date = args.add_date
     output_dir = args.output
     no_poi = args.no_poi
-    no_image = args.no_image
+    add_images = args.add_images
     language = args.language
     account_images_only = args.account_images_only
 
@@ -389,7 +389,7 @@ def main(args):
     if tour_selection == "all":
         for x in tours:
             make_gpx(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, max_desc_length, language)
-            if not no_image and not anonymous:
+            if add_images and not anonymous:
                 download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, account_images_only)
     else:
         if anonymous:
@@ -397,11 +397,11 @@ def main(args):
         else:
             if int(tour_selection) in tours:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, max_desc_length, language)
-                if not no_image:
+                if add_images:
                     download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, account_images_only)
             else:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, max_desc_length, language)
-                if not no_image:
+                if add_images:
                     download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, account_images_only)
     print()
 
@@ -450,7 +450,7 @@ def parse_args():
     parser.add_argument("--private-only", action="store_true", help="Include only private tours")
     parser.add_argument("--public-only", action="store_true", help="Include only public tours")
     parser.add_argument("-o", "--output", type=str, default=os.getcwd(), help="Output directory")
-    parser.add_argument("-i", "--no-image", action="store_true", help="Do not download tour images")
+    parser.add_argument("-i", "--add-images", action="store_true", default=False, help="Add tour images")
     parser.add_argument("--account-images-only", action="store_true", help="Only download images belong to this account")
     parser.add_argument("-e", "--no-poi", action="store_true", help="Do not include POIs in GPX")
     parser.add_argument("--debug", action="store_true", default=False, help="Debug")

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -397,6 +397,8 @@ def main(args):
     else:
         if anonymous:
             make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date, max_title_length, max_desc_length, language)
+            if add_images:
+                print_warning(f"Warning: No image download in anonymous mode.")
         else:
             if int(tour_selection) in tours:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, max_desc_length, language)

--- a/komootgpx/utils.py
+++ b/komootgpx/utils.py
@@ -59,3 +59,10 @@ def sanitize_filename(value):
     for c in '\\/:*?"<>|':
         value = value.replace(c, '')
     return value
+
+def shorten_path(path: str, max_len: int = 60) -> str:
+    if len(path) <= max_len:
+        return path
+    # Keep start and end, replace middle with "..."
+    keep = (max_len - 3) // 2
+    return f"{path[:keep]}...{path[-keep:]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,17 @@ name = "komootgpx"
 dynamic = ["version"]
 description = "Download Komoot tracks and highlights as GPX files (including metadata). Supports bulk-download."
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.6.0"
+requires-python = ">=3.9"
 license = "GPL-3.0-only"
 authors = [
   {name = "Tim Schneeberger", email = "tim.schneeberger@outlook.de"}
 ]
 dependencies = [
-  "argparse",
   "certifi",
   "chardet",
+  "piexif",
   "gpxpy",
+  "pillow",
   "colorama",
   "idna",
   "requests",


### PR DESCRIPTION
This PR is about adding the possibility to also download the tour related images and save them with included title and coordinates, `--add-images`. If not skipped with `--no-poi`, it also downloads the cover image from tour highlights.

As per default, only images belonging to the given account will be downloaded. With the parameter `--all-images`, it will be possible to also download images from tour highlights, which comes from third party.
