### PR TITLE
Add custom (edited) Komoot waypoints as POIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Download Komoot tracks and highlights as GPX files with metadata
 * Includes metadata such as estimated duration, total elevation, difficulty and the original Komoot trip URL
 * Can add trip highlights as POIs into the GPX file
   * Includes user comments & image URLs for each highlight POI, as those often contain helpful information about the location
+  * Additionally custom Komoot waypoints can be added as POIs
 
 
 ## Installation

--- a/komootgpx/gpxcompiler.py
+++ b/komootgpx/gpxcompiler.py
@@ -2,6 +2,14 @@ from datetime import datetime, timedelta
 
 import gpxpy.gpx
 
+category2type = dict(enumerate(["Generic", "Summit", "Valley", "Water", "Food", "Danger", "First aid", "Segment start", "Segment end",
+"Campsite", "Aid station", "Rest area", "Service", "Checkpoint", "Meeting point", "Toilet", "Gear", "Sharp curve",
+"Steep incline", "Tunnel", "Shower", "Bridge", "Obstacle", "Crossing", "Store", "Transition", "Transport", "Info",
+"Cafe", "Restaurant", "Art", "Parking", "Park", "Beach", "Viewpoint", "Bike shop", "Attraction", "Gas station",
+"Lodging", "Pub"]))
+
+karootypes = ["Camping", "Danger", "Food", "Geocache", "Lodging", "Parking", "Summit", "Water"]
+karooremap = {"Campsite" : "Camping"}
 
 class Point:
     CONST_UNDEFINED = -9999
@@ -58,7 +66,7 @@ class GpxCompiler:
         self.pois = []
         if "timeline" in tour["_embedded"] and "_embedded" in tour["_embedded"]["timeline"]:
             for item in tour["_embedded"]["timeline"]["_embedded"]["items"]:
-                if item["type"] != "poi" and item["type"] != "highlight":
+                if item["type"] != "poi" and item["type"] != "highlight" and item["type"] != "point":
                     continue
 
                 ref = item["_embedded"]["reference"]
@@ -101,6 +109,30 @@ class GpxCompiler:
                         details = details[:max_desc_length - 3] + "..."
 
                     self.pois.append(POI(name, point, image_url, url, details, "Highlight"))
+
+                elif item["type"] == "point" and "category" in ref: # points without category are pointless (usually starting/ending point)
+                    name = "Unknown Point"
+                    category = ref["category"]
+                    point = Point({})
+
+                    if "name" in ref:
+                        name = ref["name"]
+                    if "location" in ref:
+                        point = Point(ref["location"])
+
+                    details = ""
+                    if "description" in ref:
+                        details =ref["description"]
+                        if max_desc_length == 0:
+                            details = ""
+                        elif max_desc_length > 0 and len(details) > max_desc_length:
+                            details = details[:max_desc_length - 3] + "..."
+
+                    type = "Generic"
+                    if category in category2type:
+                        type = category2type[category]
+
+                    self.pois.append(POI(name, point, '', '', details, type))
 
     def generate(self):
         gpx = gpxpy.gpx.GPX()
@@ -164,8 +196,11 @@ class GpxCompiler:
                 wp.type = poi.type
                 wp.comment = poi.image_url
                 if self.karoo:
-                    wp.type = "Generic"
-                    wp.symbol = "Generic"
+                    if wp.type in karooremap:
+                        wp.type = karooremap[type]
+                    if wp.type not in karootypes:
+                        wp.type = "Generic"
+                    wp.symbol = wp.type
 
                 gpx.waypoints.append(wp)
 

--- a/komootgpx/gpxcompiler.py
+++ b/komootgpx/gpxcompiler.py
@@ -197,7 +197,7 @@ class GpxCompiler:
                 wp.comment = poi.image_url
                 if self.karoo:
                     if wp.type in karooremap:
-                        wp.type = karooremap[type]
+                        wp.type = karooremap[wp.type]
                     if wp.type not in karootypes:
                         wp.type = "Generic"
                     wp.symbol = wp.type


### PR DESCRIPTION
Every waypoint in Komoot has option to edit: one can change category, name and description. With this change it will be added as POI.

Starting/ending point are omitted (they are listed as "special" points but don't have any category applied by default - although one can customize them as well).

<img width="287" height="455" alt="image" src="https://github.com/user-attachments/assets/5a0d5eb8-873d-4c18-aa29-4b1c65abf920" />
