### PR TITLE
add -S --skip-unchanged; add -f --filename-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ komootgpx.py [options]
         -r, --remove-deleted               Remove GPX files (from --output dir) without corresponding tour
                                                 in Komoot (deleted and previous versions)
         -f, --filename-pattern=pattern     Specify filename pattern, default: "{title}-{id}.gpx",
-                                                available fields: title, id, date, datetime
+                                                available fields: title, id, date, time
         -I, --id-filename                  Use only tour id for filename (no title), equal to -f "{id}.gpx"
         -D, --add-date                     Add tour date to file name, equal to -f "{date}_{title}-{id}.gpx"
         --max-title-length=num             Crop title used in filename to given length

--- a/README.md
+++ b/README.md
@@ -63,18 +63,27 @@ komootgpx.py [options]
 [Authentication]
         -m, --mail=mail_address            Login using specified email address
         -p, --pass=password                Use provided password and skip interactive prompt
-        -n, --anonymous                    Skip authentication, no interactive prompt, valid only with -d
+        -n, --anonymous                    Skip authentication, no interactive prompt,
+                                                valid only with -d
 
 [Tours]
         -l, --list-tours                   List all tours of the logged in user
         -d, --make-gpx=tour_id             Download tour as GPX
         -a, --make-all                     Download all tours
-        -s, --skip-existing                Do not download and save GPX if the file already exists, ignored with -d
-        -r, --remove-deleted               Remove GPX files (from --output dir) without corresponding tour in Komoot (deleted and previous versions)
-        -I, --id-filename                  Use only tour id for filename (no title)
-        -D, --add-date                     Add tour date to file name
-        --max-title-length=num             Crop title used in filename to given length (default: -1 = no limit)
-        -L, --language                     Set tour description to specific language (fr, de, en..., default: en)
+        -s, --skip-existing                Do not download and save GPX if the file already exists,
+                                                ignored with -d
+        -S, --skip-unchanged               Do not download and save GPX if the tour has not changed since
+                                                last download, ignored with -d and -s
+        -r, --remove-deleted               Remove GPX files (from --output dir) without corresponding tour
+                                                in Komoot (deleted and previous versions)
+        -f, --filename-pattern=pattern     Specify filename pattern, default: "{title}-{id}.gpx",
+                                                available fields: title, id, date, datetime
+        -I, --id-filename                  Use only tour id for filename (no title), equal to -f "{id}.gpx"
+        -D, --add-date                     Add tour date to file name, equal to -f "{date}_{title}-{id}.gpx"
+        --max-title-length=num             Crop title used in filename to given length
+                                                default: -1 = no limit
+        -L, --language                     Set tour description to specific language:
+                                                fr, de, en..., default: en
 
 [Filters]
         -t, --tour-type=type               Filter by track type ("planned", "recorded" or "all")
@@ -87,7 +96,8 @@ komootgpx.py [options]
 [Generator]
         -o, --output=directory             Output directory (default: working directory)
         -e, --no-poi                       Do not include highlights as POIs
-        -K, --karoo                        Save all POIs with Generic type (Hammerhead Karoo import compatibility)
+        -K, --karoo                        Save all POIs with Generic type
+                                                (Hammerhead Karoo import compatibility)
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
 
 [Images]

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -42,22 +42,27 @@ class KomootApi:
                 exit(1)
         return r
 
-    def login(self, email, password, token=None):
+    def login(self, email, password):
         print("Logging in...")
 
-        if token is None:
-            r = self.__send_request("https://api.komoot.de/v006/account/email/" + email + "/",
-                                        BasicAuthToken(email, password))
+        r = self.__send_request("https://api.komoot.de/v006/account/email/" + email + "/",
+                                    BasicAuthToken(email, password))
 
-            self.user_id = r.json()['username']
-            self.token = r.json()['password']
-            self.display_name = r.json()["user"]["displayname"]
-        else:
-            self.user_id = email
-            self.token = token
+        rj = r.json()
+        self.user_id = rj['username']
+        self.token = rj['password']
+        self.display_name = rj["user"]["displayname"]
 
         print("Logged in as '" + self.display_name + "'")
-        return self.user_id, self.token, self.display_name
+
+    def login_with_token(self, user_id, token, display_name):
+        print("Logging in with token...")
+
+        self.user_id = user_id
+        self.token = token
+        self.display_name = display_name
+
+        print("Logged in as '" + self.display_name + "'")
 
     def fetch_tours(self, tour_type="tour_all", silent=False):
         if not silent:

--- a/komootgpx/api.py
+++ b/komootgpx/api.py
@@ -1,7 +1,7 @@
+import sys
 import base64
 import json
 import requests
-import json
 
 from .utils import print_error, bcolor
 
@@ -33,13 +33,13 @@ class KomootApi:
         r = requests.get(url, auth=auth)
 
         if self.debug:
-            with open(f"komootgpx-debug-{self.request_count}.txt", "w") as dbgf:
+            with open(f"komootgpx-debug-{self.request_count}.txt", "w", encoding="utf-8") as dbgf:
                 dbgf.write(r.text)
 
         if r.status_code != 200:
             print_error("Error " + str(r.status_code) + ": " + str(r.json()))
             if critical:
-                exit(1)
+                sys.exit(1)
         return r
 
     def login(self, email, password):

--- a/komootgpx/gpxcompiler.py
+++ b/komootgpx/gpxcompiler.py
@@ -34,13 +34,13 @@ class Point:
 
 
 class POI:
-    def __init__(self, name, point, image_url, url, description, type):
+    def __init__(self, name, point, image_url, url, description, poitype):
         self.name = name
         self.point = point
         self.url = url
         self.image_url = image_url
         self.description = description
-        self.type = type
+        self.type = poitype
 
 
 def extract_user_from_tip(json):
@@ -128,11 +128,11 @@ class GpxCompiler:
                         elif max_desc_length > 0 and len(details) > max_desc_length:
                             details = details[:max_desc_length - 3] + "..."
 
-                    type = "Generic"
+                    poitype = "Generic"
                     if category in category2type:
-                        type = category2type[category]
+                        poitype = category2type[category]
 
-                    self.pois.append(POI(name, point, '', '', details, type))
+                    self.pois.append(POI(name, point, '', '', details, poitype))
 
     def generate(self):
         gpx = gpxpy.gpx.GPX()

--- a/komootgpx/gpxcompiler.py
+++ b/komootgpx/gpxcompiler.py
@@ -167,7 +167,7 @@ class GpxCompiler:
         track.segments.append(segment)
 
         augment_timestamp = self.route[0].time == 0
-        start_date = datetime.strptime(self.tour['date'], "%Y-%m-%dT%H:%M:%S.%f%z")
+        start_date = datetime.strptime(self.tour['changed_at'], "%Y-%m-%dT%H:%M:%S.%f%z")
 
         for coord in self.route:
             point = gpxpy.gpx.GPXTrackPoint(coord.lat, coord.lng)

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -13,6 +13,10 @@ from .utils import *
 
 import argparse
 
+# in minutes
+SESSION_TTL = 15
+CREDFILE = "credentials.json"
+
 init()
 interactive_info_shown = False
 
@@ -371,34 +375,39 @@ def main(args):
 
     if not anonymous:
         token = None
-        if os.path.exists("credentials.json"):
-            with open("credentials.json", "r", encoding="utf-8") as credfile:
+        uid = None
+        if os.path.exists(CREDFILE):
+            with open(CREDFILE, "r", encoding="utf-8") as credfile:
                 creddata = json.load(credfile)
-                mail = creddata.get("user_id")
+                uid = creddata.get("user_id")
                 token = creddata.get("token")
                 date = creddata.get("date")
-                if datetime.now().timestamp() - date > 15*60:
-                    print("Stored credentials are outdated. Please provide login details.")
+                display_name = creddata.get("display_name", "(token user)")
+
+                if datetime.now().timestamp() - date > SESSION_TTL * 60:
+                    print("Stored credentials are outdated.")
+                    uid = None
                     token = None
-                api.display_name = creddata.get("display_name", "(token user)")
-                pwd = ""
-                if mail and token:
-                    print("Using stored credentials for user:", mail)
-                else:
-                    print_error("Stored credentials are incomplete. Please provide login details.")
+                elif uid is None or token is None:
+                    print_error("Stored credentials are incomplete.")
+                    os.unlink(CREDFILE)
                     sys.exit(1)
 
-        if mail is None:
-            notify_interactive()
-            mail = prompt("Enter your mail address (komoot login)")
+        if uid and token:
+            print("Using stored credentials for user:", mail)
+            api.login_with_token(uid, token, display_name)
+        else:
+            if mail is None:
+                notify_interactive()
+                mail = prompt("Enter your mail address (komoot login)")
 
-        if pwd is None:
-            notify_interactive()
-            pwd = prompt_pass("Enter your password (input hidden)")
+            if pwd is None:
+                notify_interactive()
+                pwd = prompt_pass("Enter your password (input hidden)")
 
-        api.login(mail, pwd, token)
+            api.login(mail, pwd)
 
-        with open("credentials.json", "w", encoding="utf-8") as credfile:
+        with open(CREDFILE, "w", encoding="utf-8") as credfile:
             creddata = {"user_id": api.user_id, "token": api.token, "display_name": api.display_name, "date": datetime.now().timestamp()}
             json.dump(creddata, credfile)
 

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -1,23 +1,21 @@
 import os
 import re
 import sys
-from datetime import datetime, timezone
-import json
-
-from colorama import init
-
-from .api import *
-from .gpxcompiler import *
-from .imagedownload import *
-from .utils import *
-
 import argparse
+import json
+from datetime import datetime
+from colorama import init as colorama_init
+
+from .api import KomootApi
+from .gpxcompiler import GpxCompiler
+from .imagedownload import ImageDownloaderWithExif
+from .utils import *
 
 # in minutes
 SESSION_TTL = 15
 CREDFILE = "credentials.json"
 
-init()
+colorama_init()
 interactive_info_shown = False
 
 output_dir_contents = set()
@@ -156,11 +154,6 @@ def notify_interactive():
     if interactive_info_shown:
         print("Interactive mode. Use '--help' for usage details.")
 
-def parse_date_str(date_str):
-    # Handles ISO 8601 with 'Z' suffix
-    # python 3.11 has datetime.fromisoformat() with support of Z
-    return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
-
 def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, tour_base, filename_pattern, max_title_length, max_desc_length, language, karoo=False):
     tour = None
     if tour_base is None:
@@ -203,9 +196,8 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
         tour = api.fetch_tour(str(tour_id), language=language)
     gpx = GpxCompiler(tour, api, no_poi, max_desc_length, karoo)
 
-    f = open(path, "w", encoding="utf-8")
-    f.write(gpx.generate())
-    f.close()
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(gpx.generate())
 
     # set file mtime/atime to the value of `changed_at` property of tour
     os.utime(path, (tour_changed_at, tour_changed_at))
@@ -368,7 +360,7 @@ def main(args):
         os.makedirs(output_dir)
     for f in os.listdir(output_dir):
         if not os.path.isfile(f) or not gpxpat.match(f):
-            next
+            continue
         output_dir_contents.add(f)
 
     api = KomootApi(debug=args.debug)

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -33,7 +33,7 @@ def usage():
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-s', '--skip-existing', 'Do not download and save GPX if the file already exists, ignored with -d'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-S', '--skip-unchanged', 'Do not download and save GPX if the tour has not changed since last download, ignored with -d and -s'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-r', '--remove-deleted', 'Remove GPX files (from --output dir) without corresponding tour in Komoot (deleted and previous versions)'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filename-pattern=pattern', 'Specify filename pattern, default: "{title}-{id}.gpx", available fields: title, id, date, datetime'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filename-pattern=pattern', 'Specify filename pattern, default: "{title}-{id}.gpx", available fields: title, id, date, time'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-I', '--id-filename', 'Use only tour id for filename (no title), equal to -f "{id}.gpx"'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add tour date to file name, equal to -f "{date}_{title}-{id}.gpx"'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-L', '--language', 'Select description language (fr, de, en..., default: en)'))
@@ -157,10 +157,6 @@ def parse_date_str(date_str):
     # python 3.11 has datetime.fromisoformat() with support of Z
     return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
 
-def get_file_mtime(path):
-    # return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
-    return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
-
 def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, tour_base, filename_pattern, max_title_length, max_desc_length, language, karoo=False):
     tour = None
     if tour_base is None:
@@ -177,6 +173,7 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
 
     filename = filename_pattern.format(
         date = tour_base['changed_at'][:10],
+        time = re.sub(r'.*T(\d+):(\d+):(\d+).*', '\1:\2:\3', tour_base['changed_at']),
         title = file_title,
         id = tour_id
         )
@@ -211,7 +208,7 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
 
     print_success(f"GPX file written to '{path}'")
 
-def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, image_pattern, max_title_length, all_images):
+def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, image_dir_pattern, max_title_length, all_images):
     image_dir_contents = set()
     images = api.fetch_tour_images(str(tour_id), silent=False)
 
@@ -225,8 +222,9 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
         elif max_title_length > 0 and len(file_title) > max_title_length:
             file_title = file_title[:max_title_length]
 
-        image_dir_name = image_pattern.format(
+        image_dir_name = image_dir_pattern.format(
             date = tour_base['changed_at'][:10],
+            time = re.sub(r'.*T(\d+):(\d+):(\d+).*', '\1:\2:\3', tour_base['changed_at']),
             title = file_title,
             id = tour_id
             )
@@ -328,14 +326,14 @@ def main(args):
     max_desc_length = args.max_desc_length
 
     filename_pattern = args.filename_pattern
-    image_pattern = "{title}-{id}_images/{image}.jpg"
+    image_dir_pattern = "{title}-{id}_images"
 
     if args.add_date:
         filename_pattern = "{date}_{title}-{id}.gpx"
-        image_pattern = "{date}_{title}-{id}_images"
+        image_dir_pattern = "{date}_{title}-{id}_images"
     elif args.id_filename:
         filename_pattern = "{id}.gpx"
-        image_pattern = "{id}_images"
+        image_dir_pattern = "{id}_images"
 
     output_dir = args.output
     no_poi = args.no_poi
@@ -430,7 +428,7 @@ def main(args):
         for x in tours:
             make_gpx(x, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[x], filename_pattern, max_title_length, max_desc_length, language, karoo)
             if add_images and not anonymous:
-                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], image_pattern, max_title_length, all_images)
+                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], image_dir_pattern, max_title_length, all_images)
     else:
         if anonymous:
             make_gpx(tour_selection, api, output_dir, no_poi, False, False, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
@@ -440,11 +438,11 @@ def main(args):
             if int(tour_selection) in tours:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[int(tour_selection)], filename_pattern, max_title_length, max_desc_length, language, karoo)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], image_pattern, max_title_length, all_images)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], image_dir_pattern, max_title_length, all_images)
             else:
                 make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, image_pattern, max_title_length, all_images)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, image_dir_pattern, max_title_length, all_images)
     print()
 
     if remove_deleted:

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-import datetime
+from datetime import datetime, timezone
 import json
 
 from colorama import init
@@ -61,10 +61,13 @@ def usage():
 
 def is_tour_in_date_range(tour, start_date, end_date):
     """Check if a tour falls within the specified date range."""
-    if 'date' not in tour:
-        return True  # If tour has no date info, include it
+    if 'changed_at' not in tour:
+        if 'date' in tour:
+            tour['changed_at'] = tour['date']
+        else:
+            return True  # If tour has no date info (both date and changed_at), include it
 
-    tour_date_str = tour['date'][:10]  # Extract YYYY-MM-DD
+    tour_date_str = tour['changed_at'][:10]  # Extract YYYY-MM-DD
     tour_date = datetime.strptime(tour_date_str, "%Y-%m-%d").date()
 
     # If only start_date is provided, include all tours on or after start_date
@@ -147,6 +150,14 @@ def notify_interactive():
     if interactive_info_shown:
         print("Interactive mode. Use '--help' for usage details.")
 
+def parse_date_str(date_str):
+    # Handles ISO 8601 with 'Z' suffix
+    # python 3.11 has datetime.fromisoformat() with support of Z
+    return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+
+def get_file_mtime(path):
+    # return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+    return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
 
 def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, max_desc_length, language, karoo=False):
     tour = None
@@ -154,27 +165,40 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
         tour_base = api.fetch_tour(str(tour_id), language=language)
         tour = tour_base
 
-    # Example date: 2022-01-02T12:26:41.795+01:00
-    # :10 extracts "2022-01-02" from this.
-    date_str = tour_base['date'][:10]+'_' if add_date else ''
+    tour_changed_at = parse_date_str(tour_base['changed_at']).timestamp()
 
-    filename = sanitize_filename(tour_base['name'])
+    file_title = sanitize_filename(tour_base['name'])
     if max_title_length == 0:
-        filename = f"{tour_id}"
-    elif max_title_length > 0 and len(filename) > max_title_length:
-        filename = f"{filename[:max_title_length]}-{tour_id}"
-    else:
-        filename = f"{filename}-{tour_id}"
+        file_title = ""
+    elif max_title_length > 0 and len(file_title) > max_title_length:
+        file_title = file_title[:max_title_length]
 
-    fullname = f"{date_str}{filename}.gpx"
+    filename_pattern = "{title}-{tour_id}.gpx"
+    if add_date:
+        filename_pattern = "{changed_date}_{title}-{tour_id}.gpx"
+
+    filename = filename_pattern.format(
+        changed_date = tour_base['changed_at'][:10],
+        title = file_title,
+        tour_id = tour_id
+        )
+
+    fullname = sanitize_filename(filename)
     path = f"{output_dir}/{fullname}"
 
     if fullname in output_dir_contents:
         output_dir_contents.remove(fullname)
 
     if skip_existing and os.path.exists(path):
-        print_success(f"{tour_base['name']} skipped - already exists at '{path}'")
-        return
+        gpx_mtime = os.path.getmtime(path)
+
+        if gpx_mtime >= tour_changed_at:
+            print_success(f"{tour_base['name']} skipped - unchanged at '{path}'")
+            return
+
+        print_success(f"{tour_base['name']} updated")
+
+
 
     if tour is None:
         tour = api.fetch_tour(str(tour_id), language=language)
@@ -184,6 +208,9 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
     f.write(gpx.generate())
     f.close()
 
+    # set file mtime/atime to the value of `changed_at` property of tour
+    os.utime(path, (tour_changed_at, tour_changed_at))
+
     print_success(f"GPX file written to '{path}'")
 
 def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, all_images):
@@ -191,7 +218,7 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
     images = api.fetch_tour_images(str(tour_id), silent=False)
 
     if len(images) > 0:
-        date_str = tour_base['date'][:10]+'_' if add_date else ''
+        date_str = tour_base['changed_at'][:10]+'_' if add_date else ''
 
         directoryname = sanitize_filename(tour_base['name'])
         if max_title_length == 0:

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -28,12 +28,14 @@ def usage():
 
     print('\n' + bcolor.OKBLUE + '[Tours]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-l', '--list-tours', 'List all tours of the logged in user'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-d', '--make-gpx=tour_id', 'Download tour as GPX'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-d', '--make-gpx=tour_id', 'Download single tour as GPX'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-a', '--make-all', 'Download all tours'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-s', '--skip-existing', 'Do not download and save GPX if the file already exists, ignored with -d'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-S', '--skip-unchanged', 'Do not download and save GPX if the tour has not changed since last download, ignored with -d and -s'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-r', '--remove-deleted', 'Remove GPX files (from --output dir) without corresponding tour in Komoot (deleted and previous versions)'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-I', '--id-filename', 'Use only tour id for filename (no title)'))
-    print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add tour date to file name'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filename-pattern=pattern', 'Specify filename pattern, default: "{title}-{id}.gpx", available fields: title, id, date, datetime'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-I', '--id-filename', 'Use only tour id for filename (no title), equal to -f "{id}.gpx"'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add tour date to file name, equal to -f "{date}_{title}-{id}.gpx"'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-L', '--language', 'Select description language (fr, de, en..., default: en)'))
     print('\t{:<34s} {:<10s}'.format('--max-title-length=num', 'Crop title used in filename to given length (default: -1 = no limit)'))
 
@@ -159,7 +161,7 @@ def get_file_mtime(path):
     # return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
     return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
 
-def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, max_desc_length, language, karoo=False):
+def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, tour_base, filename_pattern, max_title_length, max_desc_length, language, karoo=False):
     tour = None
     if tour_base is None:
         tour_base = api.fetch_tour(str(tour_id), language=language)
@@ -173,14 +175,10 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
     elif max_title_length > 0 and len(file_title) > max_title_length:
         file_title = file_title[:max_title_length]
 
-    filename_pattern = "{title}-{tour_id}.gpx"
-    if add_date:
-        filename_pattern = "{changed_date}_{title}-{tour_id}.gpx"
-
     filename = filename_pattern.format(
-        changed_date = tour_base['changed_at'][:10],
+        date = tour_base['changed_at'][:10],
         title = file_title,
-        tour_id = tour_id
+        id = tour_id
         )
 
     fullname = sanitize_filename(filename)
@@ -190,15 +188,15 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
         output_dir_contents.remove(fullname)
 
     if skip_existing and os.path.exists(path):
+        print_success(f"{tour_base['name']} skipped - already exists at '{path}'")
+        return
+
+    if skip_unchanged and os.path.exists(path):
         gpx_mtime = os.path.getmtime(path)
 
         if gpx_mtime >= tour_changed_at:
             print_success(f"{tour_base['name']} skipped - unchanged at '{path}'")
             return
-
-        print_success(f"{tour_base['name']} updated")
-
-
 
     if tour is None:
         tour = api.fetch_tour(str(tour_id), language=language)
@@ -213,23 +211,28 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_dat
 
     print_success(f"GPX file written to '{path}'")
 
-def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, add_date, max_title_length, all_images):
+def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, image_pattern, max_title_length, all_images):
     image_dir_contents = set()
     images = api.fetch_tour_images(str(tour_id), silent=False)
 
     if len(images) > 0:
-        date_str = tour_base['changed_at'][:10]+'_' if add_date else ''
 
-        directoryname = sanitize_filename(tour_base['name'])
+        tour_changed_at = parse_date_str(tour_base['changed_at']).timestamp()
+
+        file_title = sanitize_filename(tour_base['name'])
         if max_title_length == 0:
-            directoryname = f"{tour_id}"
-        elif max_title_length > 0 and len(directoryname) > max_title_length:
-            directoryname = f"{directoryname[:max_title_length]}-{tour_id}"
-        else:
-            directoryname = f"{directoryname}-{tour_id}"
+            file_title = ""
+        elif max_title_length > 0 and len(file_title) > max_title_length:
+            file_title = file_title[:max_title_length]
 
-        fullname = f"{date_str}{directoryname}_images"
-        image_dir = f"{output_dir}/{fullname}"
+        image_dir_name = image_pattern.format(
+            date = tour_base['changed_at'][:10],
+            title = file_title,
+            id = tour_id
+            )
+
+        image_dir_name = sanitize_filename(image_dir_name)
+        image_dir = f"{output_dir}/{image_dir_name}"
 
         if os.path.exists(image_dir):
             imagepat = re.compile(r"\.jpg$")
@@ -297,6 +300,7 @@ def main(args):
 
     print_tours = args.list_tours
     skip_existing = args.skip_existing
+    skip_unchanged = args.skip_unchanged
     remove_deleted = args.remove_deleted
 
     if args.make_all and args.make_gpx:
@@ -319,16 +323,20 @@ def main(args):
         sys.exit(2)
 
     tour_type = f"tour_{args.tour_type}"
-    max_title_length = 0 if args.id_filename else args.max_title_length
 
-    if args.id_filename:
-        max_title_length = 0
-    elif args.max_title_length:
-        max_title_length = args.max_title_length
-
+    max_title_length = args.max_title_length
     max_desc_length = args.max_desc_length
 
-    add_date = args.add_date
+    filename_pattern = args.filename_pattern
+    image_pattern = "{title}-{id}_images/{image}.jpg"
+
+    if args.add_date:
+        filename_pattern = "{date}_{title}-{id}.gpx"
+        image_pattern = "{date}_{title}-{id}_images"
+    elif args.id_filename:
+        filename_pattern = "{id}.gpx"
+        image_pattern = "{id}_images"
+
     output_dir = args.output
     no_poi = args.no_poi
     karoo = args.karoo
@@ -420,23 +428,23 @@ def main(args):
 
     if tour_selection == "all":
         for x in tours:
-            make_gpx(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, max_desc_length, language, karoo)
+            make_gpx(x, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[x], filename_pattern, max_title_length, max_desc_length, language, karoo)
             if add_images and not anonymous:
-                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], add_date, max_title_length, all_images)
+                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], image_pattern, max_title_length, all_images)
     else:
         if anonymous:
-            make_gpx(tour_selection, api, output_dir, no_poi, False, None, add_date, max_title_length, max_desc_length, language, karoo)
+            make_gpx(tour_selection, api, output_dir, no_poi, False, False, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
             if add_images:
                 print_warning(f"Warning: No image download in anonymous mode.")
         else:
             if int(tour_selection) in tours:
-                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, max_desc_length, language, karoo)
+                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[int(tour_selection)], filename_pattern, max_title_length, max_desc_length, language, karoo)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], add_date, max_title_length, all_images)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], image_pattern, max_title_length, all_images)
             else:
-                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, max_desc_length, language, karoo)
+                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
                 if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, add_date, max_title_length, all_images)
+                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, image_pattern, max_title_length, all_images)
     print()
 
     if remove_deleted:
@@ -470,10 +478,12 @@ def parse_args():
     parser.add_argument("-d", "--make-gpx", type=int, help="Download GPX for selected tour")
     parser.add_argument("-a", "--make-all", action="store_true", help="Download all tours")
     parser.add_argument("-s", "--skip-existing", action="store_true", help="Skip already downloaded tours")
+    parser.add_argument("-S", "--skip-unchanged", action="store_true", help="Skip tours that have not changed since last download")
     parser.add_argument("-r", "--remove-deleted", action="store_true", help="Remove gpx files for nonexistent tours")
+    parser.add_argument("-f", "--filename-pattern", type=str, default="{title}-{id}.gpx", help="Filename pattern")
     parser.add_argument("-I", "--id-filename", action="store_true",
-                        help="Use ID as filename (max title length = 0)")
-    parser.add_argument("-D", "--add-date", action="store_true", help="Add date to filename")
+                        help="Use tour ID as filename")
+    parser.add_argument("-D", "--add-date", action="store_true", help="Prepend filename with tour modification date")
     parser.add_argument("--max-title-length", type=int, default=-1, help="Maximum length for titles")
     parser.add_argument("--max-desc-length", type=int, default=-1, help="Maximum length for descriptions")
     parser.add_argument("-t", "--tour-type", choices=["planned", "recorded", "all"], default="all",

--- a/komootgpx/utils.py
+++ b/komootgpx/utils.py
@@ -1,5 +1,5 @@
 import getpass
-
+import re
 
 class bcolor:
     HEADER = '\033[95m'
@@ -59,6 +59,36 @@ def sanitize_filename(value):
     for c in '\\/:*?"<>|':
         value = value.replace(c, '')
     return value
+
+def sanitize_filename(value):
+    # Remove NUL and the only real Unix path separator
+    value = value.replace('\0', '').replace('/', '')
+
+
+RESERVED_NAMES = {
+    'CON', 'PRN', 'AUX', 'NUL',
+    *(f'COM{i}' for i in range(1, 10)),
+    *(f'LPT{i}' for i in range(1, 10)),
+    '.', '..', ''
+}
+
+def sanitize_filename(value):
+    # Strip illegal chars and control characters
+    value = re.sub(r'[\\/:*?"<>|\x00-\x1f]', '', value)
+
+    # Strip trailing dots/spaces (strange Windows rule)
+    value = value.rstrip('. ')
+
+    name_part = value.split('.')[0].upper()
+    if name_part in RESERVED_NAMES:
+        value = '_' + value
+
+    if not value:
+        value = 'unnamed'
+
+    return value
+
+
 
 def shorten_path(path: str, max_len: int = 60) -> str:
     if len(path) <= max_len:

--- a/komootgpx/utils.py
+++ b/komootgpx/utils.py
@@ -1,5 +1,6 @@
 import getpass
 import re
+from datetime import datetime, timezone
 
 class bcolor:
     HEADER = '\033[95m'
@@ -11,17 +12,14 @@ class bcolor:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-
 def boolToColorStr(b):
     if b:
         return bcolor.OKGREEN + "true" + bcolor.ENDC
     else:
         return bcolor.FAIL + "false" + bcolor.ENDC
 
-
 def print_error(text):
     print(bcolor.FAIL + text + bcolor.ENDC)
-
 
 def print_success(text):
     print(bcolor.OKGREEN + text + bcolor.ENDC)
@@ -41,7 +39,6 @@ def prompt(title):
     print()
     return selection
 
-
 def prompt_pass(title):
     print()
     print(bcolor.BOLD + bcolor.HEADER + title + bcolor.ENDC)
@@ -53,17 +50,6 @@ def prompt_pass(title):
         break
     print()
     return selection
-
-
-def sanitize_filename(value):
-    for c in '\\/:*?"<>|':
-        value = value.replace(c, '')
-    return value
-
-def sanitize_filename(value):
-    # Remove NUL and the only real Unix path separator
-    value = value.replace('\0', '').replace('/', '')
-
 
 RESERVED_NAMES = {
     'CON', 'PRN', 'AUX', 'NUL',
@@ -88,11 +74,14 @@ def sanitize_filename(value):
 
     return value
 
-
-
 def shorten_path(path: str, max_len: int = 60) -> str:
     if len(path) <= max_len:
         return path
     # Keep start and end, replace middle with "..."
     keep = (max_len - 3) // 2
     return f"{path[:keep]}...{path[-keep:]}"
+
+def parse_date_str(date_str):
+    # Handles ISO 8601 with 'Z' suffix
+    # python 3.11 has datetime.fromisoformat() with support of Z
+    return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)


### PR DESCRIPTION
New logic to check if tour is already downloaded - based on `changed_at` property and modification time of file. Tested on linux.

Also added custom filename formatting (to have more flexibility than `--id-filename` and `--add-date`).
