### PR TITLE
add `-v`/`--version` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ komootgpx.py [options]
 [Other]
         --debug                            Save all Komoot API responses in set of .txt files
         --clear-cache                      Remove cached credentials and file hashes
+        -v, --version                      Print version and exit
 ```
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -63,28 +63,21 @@ komootgpx.py [options]
 [Authentication]
         -m, --mail=mail_address            Login using specified email address
         -p, --pass=password                Use provided password and skip interactive prompt
-        -n, --anonymous                    Skip authentication, no interactive prompt,
-                                                valid only with -d
+        -n, --anonymous                    Skip authentication, no interactive prompt, valid only with -d
 
 [Tours]
         -l, --list-tours                   List all tours of the logged in user
-        -d, --make-gpx=tour_id             Download tour as GPX
+        -d, --make-gpx=tour_id             Download single tour as GPX
         -a, --make-all                     Download all tours
         -R, --recent=N                     Download the N most recently changed tours
-        -s, --skip-existing                Do not download and save GPX if the file already exists,
-                                                ignored with -d
-        -S, --skip-unchanged               Do not download and save GPX if the tour has not changed since
-                                                last download (uses hash verification), ignored with -d and -s
-        -r, --remove-deleted               Remove GPX files (from --output dir) without corresponding tour
-                                                in Komoot (deleted and previous versions)
-        -f, --filename-pattern=pattern     Specify filename pattern, default: "{title}-{id}.gpx",
-                                                available fields: title, id, date, time
+        -s, --skip-existing                Do not download and save GPX if the file already exists, ignored with -d
+        -S, --skip-unchanged               Do not download and save GPX if the tour has not changed since last download (hash verification), ignored with -d and -s
+        -r, --remove-deleted               Remove GPX files (from --output dir) without corresponding tour in Komoot (deleted and previous versions)
+        -f, --filename-pattern=pattern     Specify filename pattern, default: "{title}-{id}.gpx", available fields: title, id, date, time
         -I, --id-filename                  Use only tour id for filename (no title), equal to -f "{id}.gpx"
         -D, --add-date                     Add tour date to file name, equal to -f "{date}_{title}-{id}.gpx"
-        --max-title-length=num             Crop title used in filename to given length
-                                                default: -1 = no limit
-        -L, --language                     Set tour description to specific language:
-                                                fr, de, en..., default: en
+        -L, --language                     Select description language (fr, de, en..., default: en)
+        --max-title-length=num             Crop title used in filename to given length (default: -1 = no limit)
 
 [Filters]
         -t, --tour-type=type               Filter by track type ("planned", "recorded" or "all")
@@ -97,16 +90,16 @@ komootgpx.py [options]
 [Generator]
         -o, --output=directory             Output directory (default: working directory)
         -e, --no-poi                       Do not include highlights as POIs
-        -K, --karoo                        Save all POIs with Generic type
-                                                (Hammerhead Karoo import compatibility)
+        -K, --karoo                        Save all POIs with Generic type (Hammerhead Karoo import compatibility)
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
 
 [Images]
+        --all-images                       Download images from other users too - please review the copyright
         -i, --add-images                   Add tour images
-        --all-images                       Download images from other users too - copyright review is required
 
 [Other]
         --debug                            Save all Komoot API responses in set of .txt files
+        --clear-cache                      Remove cached credentials and file hashes
 ```
 
 ### Authentication

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -14,6 +14,7 @@ from .api import KomootApi
 from .gpxcompiler import GpxCompiler
 from .imagedownload import ImageDownloaderWithExif
 from .utils import *
+from .__version__ import __version__
 
 # in minutes
 SESSION_TTL = 15
@@ -79,6 +80,7 @@ def usage():
     print('\n' + bcolor.OKBLUE + '[Other]' + bcolor.ENDC)
     print('\t{:<34s} {:<10s}'.format('--debug', 'Save all Komoot API responses in set of .txt files'))
     print('\t{:<34s} {:<10s}'.format('--clear-cache', 'Remove cached credentials and file hashes'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-v', '--version', 'Print version and exit'))
 
 
 def is_tour_in_date_range(tour, start_date, end_date):
@@ -313,6 +315,10 @@ def main(args):
     if args.help:
         usage()
         sys.exit(2)
+
+    if args.version:
+        print(f"komootgpx {__version__}")
+        sys.exit(0)
 
     if args.clear_cache:
         for f in (CREDFILE, HASHFILE):
@@ -599,4 +605,5 @@ def parse_args():
     parser.add_argument("--debug", action="store_true", default=False, help="Debug")
     parser.add_argument("--clear-cache", action="store_true", help="Clear cached credentials and file hashes")
     parser.add_argument("-h", "--help", action="store_true", help="Prints help")
+    parser.add_argument("-v", "--version", action="store_true", help="Prints version")
     return parser.parse_args()


### PR DESCRIPTION
Currently it is hard to find out which version is installed. I was looking for a `--version` argument, and since it was msising: Here it is!
I used the chance to update the README help block to match what's actually output from `--help`.