### PR TITLE
ConfigArgParse + refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ komootgpx.py [options]
 
 [Generator]
         -o, --output=directory             Output directory (default: working directory)
+        --poi                              Include highlights as POIs (default behavior)
         -e, --no-poi                       Do not include highlights as POIs
         -K, --karoo                        Save all POIs with Generic type (Hammerhead Karoo import compatibility)
         --max-desc-length=count            Limit description length in characters (default: -1 = no limit)
@@ -127,32 +128,55 @@ You can create an optional `config.yaml` file in the directory you run `komootgp
 The config file lets you set default values for options like the filename pattern, output directory, or other CLI flags, 
 so you don't need to pass them every time. 
 
-Command-line flags always override values set in the config file. However, currently boolean flags that were set to true in the config file cannot be unset by command-line flags.
+Command-line flags always override values set in the config file. Boolean flags that were set to true in the config file can be unset with long negated flag, e.g. `--no-remove-deleted`.
 
 A [`config.yaml.example`](config.yaml.example) template file is provided in the repository. Copy it to `config.yaml` and adjust the values as a starting point.
 
 ```yaml
-settings:
-    filename-pattern: "{title}-{id}.gpx"
-    max-title-length: -1
-    language: en
-    output: /path/to/output/directory
-    no-poi: false
-    karoo: false
-    add-images: false
-    all-images: false
-    skip-existing: false
-    skip-unchanged: false
-    remove-deleted: false                  
+# KomootGPX configuration file (config.yaml)
+#
+# Every key is a long command-line option name without the leading "--".
+# Values set here override the built-in defaults, and are in turn overridden by options given on the command line.
+
+# --- Authentication ---
+# email:                                 # -m  Login email (default: prompt)
+# password:                              # -p  Login password (default: prompt)
+anonymous: false                         # -n  Skip authentication (valid only with -d)
+
+# --- Tours ---
+list-tours: false                        # -l  List all tours and exit
+# make-gpx:                              # -d  Download single tour by id (default: unset)
+make-all: false                          # -a  Download all tours
+# recent:                                # -R  Download the N most recently changed tours (default: unset)
+skip-existing: false                     # -s  Skip tours whose file already exists
+skip-unchanged: false                    # -S  Skip tours unchanged since last download (hash check)
+remove-deleted: false                    # -r  Remove GPX files without a corresponding tour
+filename-pattern: "{title}-{id}.gpx"     # -f  Filename pattern (fields: title, id, date, time)
+id-filename: false                       # -I  Use only tour id as filename (= -f "{id}.gpx")
+add-date: false                          # -D  Prepend tour date (= -f "{date}_{title}-{id}.gpx")
+language: en                             # -L  Description language (fr, de, en, ...)
+max-title-length: -1                     #     Crop title in filename to N chars (-1 = no limit)
+
+# --- Filters ---
+tour-type: all                           # -t  Track type: planned, recorded or all
+# start-date:                            #     Include tours on or after YYYY-MM-DD (default: unset)
+# end-date:                              #     Include tours on or before YYYY-MM-DD (default: unset)
+# sport:                                 #     Sport type filter, e.g. hike (default: unset)
+private-only: false                      #     Include only private tours
+public-only: false                       #     Include only public tours
+
+# --- Generator ---
+output: .                                # -o  Output directory (default: working directory)
+poi: true                                # -e  Include highlights as POIs; false == -e / --no-poi
+karoo: false                             # -K  Save all POIs with Generic type (Karoo compatibility)
+max-desc-length: -1                      #     Crop description to N chars (-1 = no limit)
+
+# --- Images ---
+all-images: false                        #     Download images from other users too (check copyright)
+add-images: false                        # -i  Download tour images
+
+# --- Other ---
+debug: false                             #     Save all Komoot API responses to .txt files
+clear-cache: false                       #     Remove cached credentials and file hashes, then exit
 ```
 
-#### Auto-login
-If `email` and `password` yaml entries are added under an `auth` key in the `config.yaml` file, credentials are read automatically, no `-m`/`-p` flags needed:
-
-```yaml
-auth:
-    email: you@example.com
-    password: your-komoot-password
-```
-
-Command-line flags `-m`/`-p` override the credentials configured in the file if both are provided.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,18 +1,45 @@
-auth:
-    # Uncomment to use auto-login
-    #email: you@example.com                 # Komoot login email
-    #password: your-komoot-password         # Komoot login password
+# KomootGPX configuration file (config.yaml)
+#
+# Every key is a long command-line option name without the leading "--".
+# Values set here override the built-in defaults, and are in turn overridden by options given on the command line.
 
-settings:
-    filename-pattern: "{title}-{id}.gpx"    # Output filename pattern (-f)
-    max-title-length: -1                    # Max title chars (-1 = no limit)
-    language: en                            # Description language (-L)
-    output: .                               # Output directory (-o)
-    no-poi: false                           # Exclude highlights as POIs (-e)
-    karoo: false                            # Hammerhead Karoo compat mode (-K)
-    add-images: false                       # Download tour images (-i)
-    all-images: false                       # Include images from other users
-    skip-existing: false                    # Skip already downloaded tours (-s)
-    skip-unchanged: false                   # Skip unchanged tours via hash (-S)
-    remove-deleted: false                   # Remove GPX for deleted tours (-r)
+# --- Authentication ---
+# email:                                 # -m  Login email (default: prompt)
+# password:                              # -p  Login password (default: prompt)
+anonymous: false                         # -n  Skip authentication (valid only with -d)
 
+# --- Tours ---
+list-tours: false                        # -l  List all tours and exit
+# make-gpx:                              # -d  Download single tour by id (default: unset)
+make-all: false                          # -a  Download all tours
+# recent:                                # -R  Download the N most recently changed tours (default: unset)
+skip-existing: false                     # -s  Skip tours whose file already exists
+skip-unchanged: false                    # -S  Skip tours unchanged since last download (hash check)
+remove-deleted: false                    # -r  Remove GPX files without a corresponding tour
+filename-pattern: "{title}-{id}.gpx"     # -f  Filename pattern (fields: title, id, date, time)
+id-filename: false                       # -I  Use only tour id as filename (= -f "{id}.gpx")
+add-date: false                          # -D  Prepend tour date (= -f "{date}_{title}-{id}.gpx")
+language: en                             # -L  Description language (fr, de, en, ...)
+max-title-length: -1                     #     Crop title in filename to N chars (-1 = no limit)
+
+# --- Filters ---
+tour-type: all                           # -t  Track type: planned, recorded or all
+# start-date:                            #     Include tours on or after YYYY-MM-DD (default: unset)
+# end-date:                              #     Include tours on or before YYYY-MM-DD (default: unset)
+# sport:                                 #     Sport type filter, e.g. hike (default: unset)
+private-only: false                      #     Include only private tours
+public-only: false                       #     Include only public tours
+
+# --- Generator ---
+output: .                                # -o  Output directory (default: working directory)
+poi: true                                # -e  Include highlights as POIs; false == -e / --no-poi
+karoo: false                             # -K  Save all POIs with Generic type (Karoo compatibility)
+max-desc-length: -1                      #     Crop description to N chars (-1 = no limit)
+
+# --- Images ---
+all-images: false                        #     Download images from other users too (check copyright)
+add-images: false                        # -i  Download tour images
+
+# --- Other ---
+debug: false                             #     Save all Komoot API responses to .txt files
+clear-cache: false                       #     Remove cached credentials and file hashes, then exit

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -32,7 +32,7 @@ public-only: false                       #     Include only public tours
 
 # --- Generator ---
 output: .                                # -o  Output directory (default: working directory)
-poi: true                                # -e  Include highlights as POIs; false == -e / --no-poi
+poi: true                                #     Include highlights as POIs; false == -e / --no-poi
 karoo: false                             # -K  Save all POIs with Generic type (Karoo compatibility)
 max-desc-length: -1                      #     Crop description to N chars (-1 = no limit)
 

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -2,12 +2,14 @@ import os
 import re
 import sys
 import argparse
+import configargparse
 import json
 import hashlib
 import shutil
-import yaml
-from platformdirs import user_cache_dir
+from dataclasses import dataclass, fields
 from datetime import datetime
+
+from platformdirs import user_cache_dir
 from colorama import init as colorama_init
 
 from .api import KomootApi
@@ -69,6 +71,7 @@ def usage():
 
     print('\n' + bcolor.OKBLUE + '[Generator]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-o', '--output=directory', 'Output directory (default: working directory)'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--poi', 'Include highlights as POIs (default behavior)'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--no-poi', 'Do not include highlights as POIs'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-K', '--karoo', 'Save all POIs with Generic type (Hammerhead Karoo import compatibility)'))
     print('\t{:<34s} {:<10s}'.format('--max-desc-length=count', 'Limit description length in characters (default: -1 = no limit)'))
@@ -84,7 +87,6 @@ def usage():
 
 
 def is_tour_in_date_range(tour, start_date, end_date):
-    """Check if a tour falls within the specified date range."""
     if 'date' not in tour:
         if 'changed_at' in tour:
             tour['date'] = tour['changed_at']
@@ -174,10 +176,28 @@ def notify_interactive():
         interactive_info_shown = True
         print("Interactive mode. Use '--help' for usage details.")
 
-def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, tour_base, filename_pattern, max_title_length, max_desc_length, language, karoo=False):
+@dataclass(frozen=True)
+class RunConfig:
+    # Run-wide configuration, built once in main() after args/config merging.
+    # Only tour_id and tour_base vary between make_gpx/download_tour_images
+    api: KomootApi
+    output_dir: str
+    filename_pattern: str
+    image_dir_pattern: str
+    no_poi: bool
+    skip_existing: bool
+    skip_unchanged: bool
+    remove_deleted: bool
+    max_title_length: int
+    max_desc_length: int
+    all_images: bool
+    language: str
+    karoo: bool
+
+def make_gpx(cfg, tour_id, tour_base):
     tour = None
     if tour_base is None:
-        tour_base = api.fetch_tour(str(tour_id), language=language)
+        tour_base = cfg.api.fetch_tour(str(tour_id), language=cfg.language)
         tour = tour_base
 
     tour_changed_at = parse_date_str(tour_base['changed_at']).timestamp()
@@ -190,12 +210,12 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
             hashes = json.load(f)
 
     file_title = sanitize_filename(tour_base['name'])
-    if max_title_length == 0:
+    if cfg.max_title_length == 0:
         file_title = ""
-    elif max_title_length > 0 and len(file_title) > max_title_length:
-        file_title = file_title[:max_title_length]
+    elif cfg.max_title_length > 0 and len(file_title) > cfg.max_title_length:
+        file_title = file_title[:cfg.max_title_length]
 
-    filename = filename_pattern.format(
+    filename = cfg.filename_pattern.format(
         date = tour_base['date'][:10],
         time = re.sub(r'.*T(\d+):(\d+):(\d+).*', '\1:\2:\3', tour_base['date']),
         title = file_title,
@@ -203,24 +223,25 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
         )
 
     fullname = sanitize_filename(filename)
-    path = f"{output_dir}/{fullname}"
+    path = f"{cfg.output_dir}/{fullname}"
 
-    if fullname in output_dir_contents:
-        output_dir_contents.remove(fullname)
+    if cfg.remove_deleted:
+        if fullname in output_dir_contents:
+            output_dir_contents.remove(fullname)
 
-    if skip_existing and os.path.exists(path):
+    if cfg.skip_existing and os.path.exists(path):
         print_success(f"{tour_base['name']} skipped - already exists at '{path}'")
         return
 
-    if skip_unchanged and os.path.exists(path):
+    if cfg.skip_unchanged and os.path.exists(path):
         if hashes.get(str(tour_id)) == tour_hash:
             print_success(f"{tour_base['name']} skipped - unchanged at '{path}'")
             return
 
     if tour is None:
-        tour = api.fetch_tour(str(tour_id), language=language)
-    gpx = GpxCompiler(tour, api, no_poi, max_desc_length, karoo)
+        tour = cfg.api.fetch_tour(str(tour_id), language=cfg.language)
 
+    gpx = GpxCompiler(tour, cfg.api, cfg.no_poi, cfg.max_desc_length, cfg.karoo)
     with open(path, "w", encoding="utf-8") as f:
         f.write(gpx.generate())
 
@@ -233,24 +254,22 @@ def make_gpx(tour_id, api, output_dir, no_poi, skip_existing, skip_unchanged, to
 
     print_success(f"GPX file written to '{path}'")
 
-def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_base, image_dir_pattern, max_title_length, all_images, language="en"):
+def download_tour_images(cfg, tour_id, tour_base):
     if tour_base is None:
-        tour_base = api.fetch_tour(str(tour_id), language=language)
+        tour_base = cfg.api.fetch_tour(str(tour_id), language=cfg.language)
 
     image_dir_contents = set()
-    images = api.fetch_tour_images(str(tour_id), silent=False)
+    images = cfg.api.fetch_tour_images(str(tour_id), silent=False)
 
     if len(images) > 0:
 
-        tour_changed_at = parse_date_str(tour_base['changed_at']).timestamp()
-
         file_title = sanitize_filename(tour_base['name'])
-        if max_title_length == 0:
+        if cfg.max_title_length == 0:
             file_title = ""
-        elif max_title_length > 0 and len(file_title) > max_title_length:
-            file_title = file_title[:max_title_length]
+        elif cfg.max_title_length > 0 and len(file_title) > cfg.max_title_length:
+            file_title = file_title[:cfg.max_title_length]
 
-        image_dir_name = image_dir_pattern.format(
+        image_dir_name = cfg.image_dir_pattern.format(
             date = tour_base['date'][:10],
             time = re.sub(r'.*T(\d+):(\d+):(\d+).*', '\1:\2:\3', tour_base['date']),
             title = file_title,
@@ -258,32 +277,32 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
             )
 
         image_dir_name = sanitize_filename(image_dir_name)
-        image_dir = f"{output_dir}/{image_dir_name}"
+        image_dir = f"{cfg.output_dir}/{image_dir_name}"
 
         if os.path.exists(image_dir):
             imagepat = re.compile(r"\.jpg$")
             for f in os.listdir(image_dir):
                 if not os.path.isfile(f) or not imagepat.match(f):
-                    next
+                    continue
                 image_dir_contents.add(f)
 
     for x in images:
         creator_display_name = images[x].get('_embedded', {}).get('creator', {}).get('display_name', "")
         highlight_id = images[x].get('highlight_id', None)
-        id = images[x].get('id')
-        if highlight_id and no_poi:
+        iid = images[x].get('id')
+        if highlight_id and cfg.no_poi:
             print_success(f"Also skipped image download for highlight/poi: {highlight_id} (--no-poi)")
             continue
 
-        if not all_images and creator_display_name != api.display_name:
-            print_success(f"Image download skipped for image {id} from: {creator_display_name} - it doesn't belong to user {api.display_name}")
+        if not cfg.all_images and creator_display_name != cfg.api.display_name:
+            print_success(f"Image download skipped for image {iid} from: {creator_display_name} - it doesn't belong to user {cfg.api.display_name}")
             continue
 
         if not os.path.exists(image_dir):
             os.makedirs(image_dir)
 
         third_party_copyright = ''
-        if creator_display_name != api.display_name:
+        if creator_display_name != cfg.api.display_name:
             third_party_copyright = '-3p'
         dt = datetime.strptime(images[x]['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ")
         output_date = dt.strftime("%Y%m%d-%H%M%S")
@@ -294,15 +313,15 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
         if filename in image_dir_contents:
             image_dir_contents.remove(filename)
 
-        if skip_existing and os.path.exists(path):
+        if cfg.skip_existing and os.path.exists(path):
             print_success(f"image download skipped - id {x} already exists at '{path}'")
             continue
 
         downloader = ImageDownloaderWithExif(
             images[x],
-            api,
-            no_poi,
-            all_images,
+            cfg.api,
+            cfg.no_poi,
+            cfg.all_images,
             timezone="UTC"
         )
 
@@ -311,123 +330,25 @@ def download_tour_images(tour_id, api, output_dir, no_poi, skip_existing, tour_b
             print_success(f"Saved {shorten_path(saved_image, 120)}")
 
 def main(args):
+    output_dir = args.output
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
-    if args.help:
-        usage()
-        sys.exit(2)
-
-    if args.version:
-        print(f"komootgpx {__version__}")
-        sys.exit(0)
-
-    if args.clear_cache:
-        for f in (CREDFILE, HASHFILE):
-            if os.path.isfile(f):
-                os.unlink(f)
-                print_success(f"Removed {f}")
-        sys.exit(0)
-
-    mail = args.mail
-    pwd = args.pwd
-    anonymous = args.anonymous
-
-    # Load config
-    config = {}
-    if os.path.exists(CONFIGFILE):
-        with open(CONFIGFILE, "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f) or {}
-
-    # Apply auth from config
-    if not anonymous and not mail and not pwd:
-        auth = config.get("auth") or {}
-        if "email" in auth and "password" in auth:
-            mail = auth["email"]
-            pwd = auth["password"]
-            print_info(f"Read credentials from {CONFIGFILE}")
-            print_info(f"Logging in to user {mail}")
-
-    # Apply settings from config (override argparse defaults)
-    settings = config.get("settings", {})
-    if "filename-pattern" in settings and args.filename_pattern is None:
-        args.filename_pattern = settings["filename-pattern"]
-    if "max-title-length" in settings and args.max_title_length is None:
-        args.max_title_length = settings["max-title-length"]
-    if "output" in settings and args.output is None:
-        args.output = settings["output"]
-    if "language" in settings and args.language is None:
-        args.language = settings["language"]
-    # Note: boolean flags set from the config can currently not be unset using cmdline flags
-    if "no-poi" in settings and args.no_poi is False:
-        args.no_poi = settings["no-poi"]
-    if "karoo" in settings and args.karoo is False:
-        args.karoo = settings["karoo"]
-    if "add-images" in settings and args.add_images is False:
-        args.add_images = settings["add-images"]
-    if "all-images" in settings and args.all_images is False:
-        args.all_images = settings["all-images"]
-    if "skip-existing" in settings and args.skip_existing is False:
-        args.skip_existing = settings["skip-existing"]
-    if "skip-unchanged" in settings and args.skip_unchanged is False:
-        args.skip_unchanged = settings["skip-unchanged"]
-    if "remove-deleted" in settings and args.remove_deleted is False:
-        args.remove_deleted = settings["remove-deleted"]
-
-    # Apply final defaults for anything still None
-    if args.filename_pattern is None:
-        args.filename_pattern = "{title}-{id}.gpx"
-    if args.max_title_length is None:
-        args.max_title_length = -1
-    if args.output is None:
-        args.output = os.getcwd()             
-    if args.language is None:
-        args.language = "en"
-
-    if anonymous and (mail is not None or pwd is not None):
-        print_error("Cannot specify login/password in anonymous mode")
-        sys.exit(2)
-
-    print_tours = args.list_tours
-    skip_existing = args.skip_existing
-    skip_unchanged = args.skip_unchanged
-    remove_deleted = args.remove_deleted
-
-    if args.make_all and args.make_gpx:
-        print_error("Cannot specify both -d and -a (--make-gpx and --make-all)")
-        sys.exit(2)
-
-    recent_n = args.recent
-    if recent_n is not None and args.make_gpx:
-        print_error("Cannot specify both -d and -R (--make-gpx and --recent)")
-        sys.exit(2)
-
-    if recent_n is not None and args.make_all:
-        print_error("Cannot specify both -a and -R (--make-all and --recent)")
-        sys.exit(2)
+    process_images = args.add_images or args.all_images
 
     if args.make_all:
         tour_selection = "all"
     elif args.make_gpx:
         tour_selection = args.make_gpx
-    elif recent_n is not None:
+    elif args.recent is not None:
         tour_selection = "all"
     else:
         tour_selection = None
 
-    if anonymous and tour_selection == "all":
-        print_error("Cannot get all user's routes in anonymous mode, use -d")
-        sys.exit(2)
-
-    if remove_deleted and not args.make_all:
-        print_error("--remove-deleted works only with --make-all")
-        sys.exit(2)
-
-    tour_type = f"tour_{args.tour_type}"
-
-    max_title_length = args.max_title_length
-    max_desc_length = args.max_desc_length
+    tour_type_arg = f"tour_{args.tour_type}"
 
     filename_pattern = args.filename_pattern
-    image_dir_pattern = os.path.splitext(args.filename_pattern)[0] + "_images"
+    image_dir_pattern = os.path.splitext(filename_pattern)[0] + "_images"
 
     if args.add_date:
         filename_pattern = "{date}_" + filename_pattern
@@ -436,42 +357,50 @@ def main(args):
         filename_pattern = "{id}.gpx"
         image_dir_pattern = "{id}_images"
 
-    output_dir = args.output
-    no_poi = args.no_poi
-    karoo = args.karoo
-    add_images = args.add_images or args.all_images
-    language = args.language
-    all_images = args.all_images
-
-    # Parse date ranges
-    start_date = None
-    end_date = None
-    if args.start_date:
-        try:
-            start_date = datetime.strptime(args.start_date, "%Y-%m-%d").date()
-        except ValueError:
-            print_error(f"Invalid start date format: {args.start_date}. Use YYYY-MM-DD")
-            sys.exit(2)
-
-    if args.end_date:
-        try:
-            end_date = datetime.strptime(args.end_date, "%Y-%m-%d").date()
-        except ValueError:
-            print_error(f"Invalid end date format: {args.end_date}. Use YYYY-MM-DD")
-            sys.exit(2)
-
-    gpxpat = re.compile(r"\.gpx$")
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-    for f in os.listdir(output_dir):
-        if os.path.isfile(os.path.join(output_dir, f)) and gpxpat.search(f):
-            output_dir_contents.add(f)
+    if args.remove_deleted:
+        gpxpat = re.compile(r"\.gpx$")
+        for f in os.listdir(output_dir):
+            if os.path.isfile(os.path.join(output_dir, f)) and gpxpat.search(f):
+                output_dir_contents.add(f)
 
     api = KomootApi(debug=args.debug)
 
-    if not anonymous:
+    cfg = RunConfig(
+        api=api,
+        output_dir=output_dir,
+        filename_pattern=filename_pattern,
+        image_dir_pattern=image_dir_pattern,
+        no_poi=args.no_poi,
+        skip_existing=args.skip_existing,
+        skip_unchanged=args.skip_unchanged,
+        remove_deleted=args.remove_deleted,
+        max_title_length=args.max_title_length,
+        max_desc_length=args.max_desc_length,
+        all_images=args.all_images,
+        language=args.language,
+        karoo=args.karoo,
+    )
+
+    if args.debug:
+        resolved = {f.name: getattr(cfg, f.name) for f in fields(cfg) if f.name != "api"}
+        skip = set(resolved) | {"output", "poi", "alt_no_poi"}
+        resolved.update({name: value for name, value in vars(args).items() if name not in skip})
+
+        print_info("Effective settings (defaults < config file < command line):")
+        for name, value in sorted(resolved.items()):
+            if name == "password":
+                value = "***" if value else None  # never reveal the password
+            elif isinstance(value, bool):
+                value = boolToColorStr(value)
+            print(f"    {name:<18} = {value}")
+
+    mail = args.email
+    pwd = args.password
+
+    if not args.anonymous:
         token = None
         uid = None
+        display_name = None
         if os.path.exists(CREDFILE):
             with open(CREDFILE, "r", encoding="utf-8") as credfile:
                 creddata = json.load(credfile)
@@ -507,57 +436,56 @@ def main(args):
             creddata = {"user_id": api.user_id, "token": api.token, "display_name": api.display_name, "date": datetime.now().timestamp()}
             json.dump(creddata, credfile)
 
-        if print_tours:
-            tours = api.fetch_tours(tour_type=tour_type, silent=True)
-            list_tours(tours, start_date, end_date)
+        if args.list_tours:
+            tours = api.fetch_tours(tour_type=tour_type_arg, silent=True)
+            list_tours(tours, args.start_date, args.end_date)
             sys.exit(0)
 
         have_full_tour_list = tour_selection == "all" or tour_selection is None
         if have_full_tour_list:
-            tours = api.fetch_tours(tour_type)
-            tours = date_filter(tours, start_date, end_date)
+            tours = api.fetch_tours(tour_type_arg)
+            tours = date_filter(tours, args.start_date, args.end_date)
             tours = private_public_filter(tours, args.private_only, args.public_only)
             tours = sport_filter(tours, args.sport)
 
-            if recent_n is not None:
+            if args.recent is not None:
                 sorted_tours = sorted(tours.items(), key=lambda x: x[1].get('changed_at', ''), reverse=True)
-                tours = dict(sorted_tours[:recent_n])
+                tours = dict(sorted_tours[:args.recent])
                 print(f"Limited to {len(tours)} most recently changed tours")
         else:
             tours = {}
 
-    #
     if tour_selection is None:
         notify_interactive()
-        if not anonymous:
-            tours = api.fetch_tours(tour_type=tour_type, silent=True)
-            list_tours(tours, start_date, end_date)
+        if not args.anonymous:
+            tours = api.fetch_tours(tour_type=tour_type_arg, silent=True)
+            list_tours(tours, args.start_date, args.end_date)
         tour_selection = prompt("Enter a tour id to download")
 
-    if not anonymous and tour_selection != "all" and have_full_tour_list and int(tour_selection) not in tours:
+    if not args.anonymous and tour_selection != "all" and have_full_tour_list and int(tour_selection) not in tours:
         print_warning(f"Warning: This id ({tour_selection}) is not one of your tours. Use --list-tours to view complete list.")
 
     if tour_selection == "all":
         for x in tours:
-            make_gpx(x, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[x], filename_pattern, max_title_length, max_desc_length, language, karoo)
-            if add_images and not anonymous:
-                download_tour_images(x, api, output_dir, no_poi, skip_existing, tours[x], image_dir_pattern, max_title_length, all_images, language)
+            make_gpx(cfg, x, tours[x])
+            if process_images and not args.anonymous:
+                download_tour_images(cfg, x, tours[x])
     else:
-        if anonymous:
-            make_gpx(tour_selection, api, output_dir, no_poi, False, False, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
-            if add_images:
+        if args.anonymous:
+            make_gpx(cfg, tour_selection, None)
+            if process_images:
                 print_warning(f"Warning: No image download in anonymous mode.")
         else:
             if int(tour_selection) in tours:
-                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, tours[int(tour_selection)], filename_pattern, max_title_length, max_desc_length, language, karoo)
-                if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, tours[int(tour_selection)], image_dir_pattern, max_title_length, all_images, language)
+                make_gpx(cfg, tour_selection, tours[int(tour_selection)])
+                if process_images:
+                    download_tour_images(cfg, tour_selection, tours[int(tour_selection)])
             else:
-                make_gpx(tour_selection, api, output_dir, no_poi, skip_existing, skip_unchanged, None, filename_pattern, max_title_length, max_desc_length, language, karoo)
-                if add_images:
-                    download_tour_images(tour_selection, api, output_dir, no_poi, skip_existing, None, image_dir_pattern, max_title_length, all_images, language)
+                make_gpx(cfg, tour_selection, None)
+                if process_images:
+                    download_tour_images(cfg, tour_selection, None)
 
-    if remove_deleted:
+    if args.remove_deleted:
         for f in output_dir_contents:
             os.unlink(os.path.join(output_dir, f))
             print_success(f"{f} removed from {output_dir}")
@@ -572,42 +500,128 @@ def entrypoint():
         sys.exit(1)
 
 def parse_args():
-    parser = argparse.ArgumentParser(
+    parser = configargparse.ArgParser(
         description="Download Komoot tours and highlights as GPX files.",
-        # override the auto-created help from argparse to show usage() instead
+        default_config_files=[CONFIGFILE],
+        config_file_parser_class=configargparse.YAMLConfigFileParser,
+        # override the auto-created help to show usage() instead
         add_help=False
     )
-    parser.add_argument("-m", "--mail", type=str, help="Email address for login")
-    parser.add_argument("-p", "--pass", dest="pwd", type=str, help="Password for login")
-    parser.add_argument("-n", "--anonymous", action="store_true", default=False, help="Login anonymously")
+
+    parser.add_argument("-m", "--mail", "--email", type=str, dest="email", help="Email address for login")
+    parser.add_argument("-p", "--pass", "--password", type=str, dest="password", help="Password for login")
+    parser.add_argument("-n", "--anonymous", action="store_true", help="Login anonymously")
+
     parser.add_argument("-l", "--list-tours", action="store_true", help="Print available tours")
-    parser.add_argument("-L", "--language", type=str, default=None, help="Select description language (default=en)")
     parser.add_argument("-d", "--make-gpx", type=int, help="Download GPX for selected tour")
     parser.add_argument("-a", "--make-all", action="store_true", help="Download all tours")
     parser.add_argument("-R", "--recent", type=int, default=None, help="Download the N most recently changed tours")
-    parser.add_argument("-s", "--skip-existing", action="store_true", help="Skip already downloaded tours")
-    parser.add_argument("-S", "--skip-unchanged", action="store_true", help="Skip tours that have not changed since last download (uses hash verification)")
-    parser.add_argument("-r", "--remove-deleted", action="store_true", help="Remove gpx files for nonexistent tours")
-    parser.add_argument("-f", "--filename-pattern", type=str, default=None, help="Filename pattern")
-    parser.add_argument("-I", "--id-filename", action="store_true",
-                        help="Use tour ID as filename")
+    # NOTE: for BooleanOptionalAction the long option MUST be listed before the
+    # short one. ConfigArgParse serialises a config value using the *first*
+    # option string; if a short positive flag like "-s" comes first, a config
+    # entry "skip-existing: false" is silently turned into True. Long-first lets
+    # it emit "--no-skip-existing" and honour the false value.
+    parser.add_argument("--skip-existing", "-s", action=argparse.BooleanOptionalAction, default=False, help="Skip already downloaded tours")
+    parser.add_argument("--skip-unchanged", "-S", action=argparse.BooleanOptionalAction, default=False, help="Skip tours that have not changed since last download (uses hash verification)")
+    parser.add_argument("--remove-deleted", "-r", action=argparse.BooleanOptionalAction, default=False, help="Remove gpx files for nonexistent tours")
+    parser.add_argument("-f", "--filename-pattern", type=str, default="{title}-{id}.gpx", help="Filename pattern")
+    parser.add_argument("-I", "--id-filename", action="store_true", help="Use tour ID as filename")
     parser.add_argument("-D", "--add-date", action="store_true", help="Prepend filename with tour modification date")
-    parser.add_argument("--max-title-length", type=int, default=None, help="Maximum length for titles")
-    parser.add_argument("--max-desc-length", type=int, default=-1, help="Maximum length for descriptions")
-    parser.add_argument("-t", "--tour-type", choices=["planned", "recorded", "all"], default="all",
-                        help="Tour type to filter")
+    parser.add_argument("--max-title-length", type=int, default=-1, help="Maximum length for titles")
+    parser.add_argument("-L", "--language", type=str, default="en", help="Select description language (default=en)")
+
+    parser.add_argument("-t", "--tour-type", choices=["planned", "recorded", "all"], default="all", help="Tour type to filter")
     parser.add_argument("--start-date", type=str, help="Filter tours on or after this date (YYYY-MM-DD)")
     parser.add_argument("--end-date", type=str, help="Filter tours on or before this date (YYYY-MM-DD)")
     parser.add_argument("--sport", type=str, help="Sport type to filter (e.g., 'hike')")
     parser.add_argument("--private-only", action="store_true", help="Include only private tours")
     parser.add_argument("--public-only", action="store_true", help="Include only public tours")
-    parser.add_argument("-o", "--output", type=str, default=None, help="Output directory")
-    parser.add_argument("-i", "--add-images", action="store_true", default=None, help="Add tour images")
-    parser.add_argument("--all-images", action="store_true", default=None, help="Download images from other users too - please review the copyright")
-    parser.add_argument("-e", "--no-poi", action="store_true", help="Do not include POIs in GPX")
-    parser.add_argument("-K", "--karoo", action="store_true", help="Save all POIs with Generic type (Hammerhead Karoo import compatibility)")
+
+    parser.add_argument("-o", "--output", type=str, default=os.getcwd(), help="Output directory")
+    # --poi / -e keep default=None to resolve no_poi later
+    parser.add_argument("--poi", action=argparse.BooleanOptionalAction, default=None, help="Include POIs in GPX")
+    parser.add_argument("-e", "--alt-no-poi", action="store_true", default=None, help="Do not include POIs in GPX")
+    parser.add_argument("--karoo", "-K", action=argparse.BooleanOptionalAction, default=False, help="Save all POIs with Generic type (Hammerhead Karoo import compatibility)")
+    parser.add_argument("--max-desc-length", type=int, default=-1, help="Maximum length for descriptions")
+
+    parser.add_argument("--add-images", "-i", action=argparse.BooleanOptionalAction, default=False, help="Add tour images")
+    parser.add_argument("--all-images", action=argparse.BooleanOptionalAction, default=False, help="Download images from other users too - please review the copyright")
+
     parser.add_argument("--debug", action="store_true", default=False, help="Debug")
+
     parser.add_argument("--clear-cache", action="store_true", help="Clear cached credentials and file hashes")
     parser.add_argument("-h", "--help", action="store_true", help="Prints help")
     parser.add_argument("-v", "--version", action="store_true", help="Prints version")
-    return parser.parse_args()
+
+    args = parser.parse_args()
+
+    if args.help:
+        usage()
+        sys.exit(0)
+
+    if args.clear_cache:
+        for f in (CREDFILE, HASHFILE):
+            if os.path.isfile(f):
+                os.unlink(f)
+                print_success(f"Removed {f}")
+        sys.exit(0)
+
+    # Resolve POI handling into a single derived flag `no_poi`.
+    # `-e`/`--alt-no-poi` is a backward-compatible alias for `--no-poi`
+    # Precedence (default < config `poi:` < `--poi` / `--no-poi`) is handled for `poi` by ConfigArgParse
+    # `-e` then forces exclusion on top of that
+    if args.alt_no_poi or args.poi is False:  # -e OR --no-poi (or config poi: false)
+        args.no_poi = True
+    else:  # --poi, or nothing specified -> default is to include POIs
+        args.no_poi = False
+
+    # validation rules
+    if args.anonymous and (args.email is not None or args.password is not None):
+        print_error("Cannot specify login/password in anonymous mode")
+        sys.exit(2)
+
+    if args.make_all and args.make_gpx:
+        print_error("Cannot specify both -d and -a (--make-gpx and --make-all)")
+        sys.exit(2)
+
+    if args.recent is not None and args.make_gpx:
+        print_error("Cannot specify both -d and -R (--make-gpx and --recent)")
+        sys.exit(2)
+
+    if args.recent is not None and args.make_all:
+        print_error("Cannot specify both -a and -R (--make-all and --recent)")
+        sys.exit(2)
+
+    if args.anonymous and (args.make_all or args.recent is not None):
+        print_error("Cannot get all user's routes in anonymous mode, use -d")
+        sys.exit(2)
+
+    if args.remove_deleted and not args.make_all:
+        print_error("--remove-deleted works only with --make-all")
+        sys.exit(2)
+
+    # Parse date ranges
+    start_date = None
+    end_date = None
+    if args.start_date:
+        try:
+            start_date = datetime.strptime(args.start_date, "%Y-%m-%d").date()
+        except ValueError:
+            print_error(f"Invalid start date format: {args.start_date}. Use YYYY-MM-DD")
+            sys.exit(2)
+
+    if args.end_date:
+        try:
+            end_date = datetime.strptime(args.end_date, "%Y-%m-%d").date()
+        except ValueError:
+            print_error(f"Invalid end date format: {args.end_date}. Use YYYY-MM-DD")
+            sys.exit(2)
+
+    args.start_date = start_date
+    args.end_date = end_date
+
+    if args.debug:
+        print(parser.format_values())
+        print()
+
+    return args

--- a/komootgpx/komootgpx.py
+++ b/komootgpx/komootgpx.py
@@ -559,6 +559,10 @@ def parse_args():
         usage()
         sys.exit(0)
 
+    if args.version:
+        print(f"komootgpx {__version__}")
+        sys.exit(0)
+
     if args.clear_cache:
         for f in (CREDFILE, HASHFILE):
             if os.path.isfile(f):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "gpxpy",
   "pillow",
   "colorama",
+  "configargparse",
   "idna",
   "requests",
   "urllib3",


### PR DESCRIPTION
As described in #39 - a bit of rewrite and cleanup.
Incompatible change to `config.yaml` (see `config.yaml.example`) - sections are removed.